### PR TITLE
Add packet.c source to tds lib in Nmakefile.

### DIFF
--- a/Nmakefile
+++ b/Nmakefile
@@ -103,6 +103,7 @@ TDS_SRC =	$(TDS_DIR)\bulk.c \
 		$(TDS_DIR)\mem.c \
 		$(TDS_DIR)\net.c \
 		$(TDS_DIR)\numeric.c \
+		$(TDS_DIR)\packet.c \
 		$(TDS_DIR)\query.c \
 		$(TDS_DIR)\read.c \
 		$(TDS_DIR)\sspi.c \
@@ -134,6 +135,7 @@ TDS_OBJ =	$(TDS_OUT)\bulk.obj \
 		$(TDS_OUT)\mem.obj \
 		$(TDS_OUT)\net.obj \
 		$(TDS_OUT)\numeric.obj \
+		$(TDS_OUT)\packet.obj \
 		$(TDS_OUT)\query.obj \
 		$(TDS_OUT)\read.obj \
 		$(TDS_OUT)\sspi.obj \


### PR DESCRIPTION
It was missing and caused errors like:
```
db-lib.lib(login.obj) : error LNK2019: unresolved external symbol _tds_read_packet referenced in function _tds71_do_login
db-lib.lib(read.obj) : error LNK2001: unresolved external symbol _tds_read_packet
db-lib.lib(query.obj) : error LNK2019: unresolved external symbol _tds_put_cancel referenced in function _tds_send_cancel
db-lib.lib(net.obj) : error LNK2001: unresolved external symbol _tds_put_cancel
db-lib.lib(write.obj) : error LNK2019: unresolved external symbol _tds_write_packet referenced in function _tds_put_n
db-lib.lib(stream.obj) : error LNK2001: unresolved external symbol _tds_write_packet
```