### PR TITLE
Remove comment about generic Nmakefile rule which wouldn't work anyway.

### DIFF
--- a/Nmakefile
+++ b/Nmakefile
@@ -1,5 +1,5 @@
 # $Id: Nmakefile,v 1.14 2011-07-07 07:24:22 freddy77 Exp $
-# Build FreeTDS and assorted utilities for Win32/Win64 without an IDE. 
+# Build FreeTDS and assorted utilities for Win32/x64 without an IDE. 
 # Makefiles, unlike Visual Studio project files, are stable over time.  
 # Contributed to the public domain by James K. Lowden, February 2009
 
@@ -175,9 +175,6 @@ bsqldb: $(APPS_OUT)\bsqldb.exe
 help:
 	@echo targets: db-lib, apps, tsql, bsqldb
 
-##(APPS_OUT)\bsqldb.exe: $(APPS_DIR)\bsqldb.exe $(DBLIB_OUT)\db-lib.lib
-# Don't know how to create this dependency without explicitly defining every output. 
-
 #
 # Sadly the environment settings for building for different architectures
 # is undocumented.  Microsoft's directions are to run the requisite 
@@ -212,9 +209,9 @@ build-win32d:
 build-win32r: 
 	$(MAKE) -fNmakefile -nologo apps PLATFORM=win32 CONFIGURATION=release
 build-win64d: 
-	$(MAKE) -fNmakefile -nologo apps PLATFORM=win64 CONFIGURATION=debug
+	$(MAKE) -fNmakefile -nologo apps PLATFORM=x64 CONFIGURATION=debug
 build-win64r: 
-	$(MAKE) -fNmakefile -nologo apps PLATFORM=win64 CONFIGURATION=release
+	$(MAKE) -fNmakefile -nologo apps PLATFORM=x64 CONFIGURATION=release
 
 clean:
 	@if "" equ "$(PLATFORM)" 	PLATFORM not defined, see comments in Nmakefile >&2 && exit 1


### PR DESCRIPTION
Also, use correct, consistent 'x64' platform name in help/comments instead of 'win64'.