### PR TITLE
Add building of static versions of ct and sybdb on Windows wth CMake.

### DIFF
--- a/src/ctlib/CMakeLists.txt
+++ b/src/ctlib/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_subdirectory(unittests)
 
+set(static_lib_name ct)
 if(WIN32)
 	set(win_SRCS ../../win32/initnet.c ctlib.def)
+	set(static_lib_name libct)
 endif()
 
 add_library(ct SHARED
@@ -9,9 +11,13 @@ add_library(ct SHARED
 	${win_SRCS}
 )
 
-add_library(libct STATIC
+add_library(ct-static STATIC
 	ct.c cs.c blk.c ctutil.c
 )
+# See http://www.cmake.org/Wiki/CMake_FAQ#How_do_I_make_my_shared_and_static_libraries_have_the_same_root_name.2C_but_different_suffixes.3F
+SET_TARGET_PROPERTIES(ct-static PROPERTIES OUTPUT_NAME ${static_lib_name})
+SET_TARGET_PROPERTIES(ct PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+SET_TARGET_PROPERTIES(ct-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 
 target_link_libraries(ct tds replacements ${lib_NETWORK} ${lib_BASE})
 

--- a/src/ctlib/CMakeLists.txt
+++ b/src/ctlib/CMakeLists.txt
@@ -9,6 +9,10 @@ add_library(ct SHARED
 	${win_SRCS}
 )
 
+add_library(libct STATIC
+	ct.c cs.c blk.c ctutil.c
+)
+
 target_link_libraries(ct tds replacements ${lib_NETWORK} ${lib_BASE})
 
 if(NOT WIN32)

--- a/src/ctlib/CMakeLists.txt
+++ b/src/ctlib/CMakeLists.txt
@@ -11,6 +11,8 @@ add_library(ct SHARED
 	${win_SRCS}
 )
 
+target_link_libraries(ct tds replacements ${lib_NETWORK} ${lib_BASE})
+
 add_library(ct-static STATIC
 	ct.c cs.c blk.c ctutil.c
 )
@@ -19,7 +21,7 @@ SET_TARGET_PROPERTIES(ct-static PROPERTIES OUTPUT_NAME ${static_lib_name})
 SET_TARGET_PROPERTIES(ct PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 SET_TARGET_PROPERTIES(ct-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 
-target_link_libraries(ct tds replacements ${lib_NETWORK} ${lib_BASE})
+target_link_libraries(ct-static tds replacements ${lib_NETWORK} ${lib_BASE})
 
 if(NOT WIN32)
 	set_target_properties(ct PROPERTIES SOVERSION "4.0.0")

--- a/src/dblib/CMakeLists.txt
+++ b/src/dblib/CMakeLists.txt
@@ -11,6 +11,11 @@ add_library(sybdb SHARED
 )
 target_link_libraries(sybdb tds replacements ${lib_NETWORK} ${lib_BASE})
 
+add_library(db-lib STATIC
+	dblib.c dbutil.c rpc.c bcp.c xact.c dbpivot.c buffering.h
+)
+target_link_libraries(db-lib tds replacements ${lib_NETWORK} ${lib_BASE})
+
 if(NOT WIN32)
 	set_target_properties(sybdb PROPERTIES SOVERSION "5.0.0")
 endif()


### PR DESCRIPTION
Names are compatible with historical names used in the deprecated
Nmakefiles and so don't clash with DLL's import libs: libct.lib
and db-lib.lib respectively.