### PR TITLE
s/inet_aton/inet_pton(AF_INET, /

### DIFF
--- a/src/tds/tls.c
+++ b/src/tds/tls.c
@@ -243,7 +243,7 @@ tds_check_ip(gnutls_x509_crt_t cert, const char *hostname)
 		ret = inet_pton(AF_INET6, hostname, &ip.v6);
 	} else {
 		ip_size = 4;
-		ret = inet_aton(hostname, &ip.v4);
+		ret = inet_pton(AF_INET, hostname, &ip.v4);
 	}
 
 	if (ret != 0)
@@ -716,7 +716,7 @@ check_alt_names(X509 *cert, const char *hostname)
 		ret = inet_pton(AF_INET6, hostname, &ip.v6);
 	} else {
 		ip_size = 4;
-		ret = inet_aton(hostname, &ip.v4);
+		ret = inet_pton(AF_INET, hostname, &ip.v4);
 	}
 	if (ret == 0)
 		return -1;


### PR DESCRIPTION
There is no way to access a inet_aton function on Windows. It's used in
tls.c

Fortunately, it supports inet_pton which can be used as a replacement
for IPv4 by passing AF_INET as the first argument.