### PR TITLE
This change improves compatibility with a great number of SQL Server …

### DIFF
--- a/freetds.conf
+++ b/freetds.conf
@@ -10,7 +10,7 @@
 # server specific section
 [global]
         # TDS protocol version
-;	tds version = 4.2
+	tds version = auto
 
 	# Whether to write a TDSDUMP file for diagnostic purposes
 	# (setting this to /tmp is insecure on a multi-user system)

--- a/freetds.spec.in
+++ b/freetds.spec.in
@@ -71,7 +71,7 @@ fi
 if test ! -r "$ODBCDIR/include/sql.h"; then
 	ODBCDIR=/usr
 fi
-%configure --with-tdsver=4.2 --with-unixodbc="$ODBCDIR"
+%configure --with-tdsver=4.2 --with-unixodbc="$ODBCDIR --with-gnutls"
 make RPM_OPT_FLAGS="$RPM_OPT_FLAGS"
  
 %install 


### PR DESCRIPTION
…versions. No encrypted connection works without either gnutls or openssl. In Microsoft Azure encryption is required so users trying to use the generated RPM package find themselves getting the error message: Adaptive server connection failed. With tds version = auto and some crypto library support the issue can be solved. Since openssl is not compatible with the project licence I understand that --with-openssl is not an option for default but --with-gnutls might be a possible default option.

Questions: why cannot one configure --with-tdsver=auto? What is wrong with the auto trying algorithm? It seems really discouraged by the looks of it...