### PR TITLE
Remove unused includes for file wspiapi.h

### DIFF
--- a/include/freetds/sysdep_private.h
+++ b/include/freetds/sysdep_private.h
@@ -58,7 +58,6 @@ typedef int pid_t;
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(_WIN64)
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#include <wspiapi.h>
 #include <windows.h>
 #define READSOCKET(a,b,c)	recv((a), (char *) (b), (c), TDS_NOSIGNAL)
 #define WRITESOCKET(a,b,c)	send((a), (const char *) (b), (c), TDS_NOSIGNAL)

--- a/include/tds_sysdep_public.h.in
+++ b/include/tds_sysdep_public.h.in
@@ -26,7 +26,6 @@
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#include <wspiapi.h>
 #include <windows.h>
 #define tds_sysdep_int16_type short	/* 16-bit int */
 #define tds_sysdep_int32_type int	/* 32-bit int */


### PR DESCRIPTION
This popped up with an older Mingw version, which didn't include this header file. However there is no `Wspiapi*` function used anywhere in the FreeTDS code. So this include could be removed.