### PR TITLE
Implemented the "ApplicationIntent" property that is was introduced in TDS 7.4

### DIFF
--- a/README
+++ b/README
@@ -36,7 +36,13 @@ A User Guide, in sgml and html form, is included in this distribution.
 Also included is a reference manual, generated in HTML with Doxygen. 
 "make install" installs the HTML documentation, by default to
 /usr/local/share/doc/freetds-<version>.  
+ 
+Implemented the "ApplicationIntent" property that is new in TDS 7.4 in the current stable version of "freetds_0.91".
+You can use this by putting "ApplicationIntent=ReadOnly", in the connection string.
+If you do not set this property the default value is ReadWrite, in which case the user can fire write queries too.
+Remember to set the following as connection string if you want to do any WinAuth connections
 
+"DRIVER=FreeTDS;Server=<IP>;Port=<PORT>;Database=<DB_NAME>;UID=<USERNAME>;PWD=<PASSWORD>;ApplicationIntent=<ReadWrite/ReadOnly>;TDS_Version=7.2;"
 
 Note to Users
 =============
@@ -86,6 +92,11 @@ Side note: Brian, as many free software authors, appreciates postcards
 from all over. So if you live someplace neat (read: not Michigan) and
 want to send one, email him (brian@bruns.org) for his current snail mail
 address.
+
+TODO
+====
+Add test in the php/python for Application Intent.
+
 
 $Id: README,v 1.12.4.1 2011-11-16 01:47:16 jklowden Exp $
 

--- a/include/tds.h
+++ b/include/tds.h
@@ -840,6 +840,8 @@ typedef enum tds_encryption_level {
 #define TDS_GSSAPI_DELEGATION "enable gssapi delegation"
 /* Kerberos realm name */
 #define TDS_STR_REALM	"realm"
+/* Application Intent MSSQL 2012 support*/
+#define TDS_STR_APPLICATION_INTENT "application intent"
 
 
 /* TODO do a better check for alignment than this */
@@ -875,6 +877,7 @@ typedef struct tds_login
 	DSTR database;
 	unsigned int bulk_copy:1;
 	unsigned int suppress_language:1;
+        unsigned int application_intent:1;
 } TDSLOGIN;
 
 typedef struct tds_connection
@@ -913,6 +916,7 @@ typedef struct tds_connection
 	unsigned int suppress_language:1;
 	unsigned int gssapi_use_delegation:1;
 	unsigned int use_ntlmv2:1;
+  	unsigned int application_intent:1;
 } TDSCONNECTION;
 
 typedef struct tds_locale
@@ -1339,7 +1343,8 @@ struct tds_socket
 	unsigned int emul_little_endian:1;
 	unsigned int use_iconv:1;
 	unsigned int tds71rev1:1;
-
+	unsigned int application_intent:1;
+  
 	unsigned char *in_buf;		/**< input buffer */
 	unsigned char *out_buf;		/**< output buffer */
 	unsigned int in_buf_max;	/**< allocated input buffer */

--- a/include/tds.h
+++ b/include/tds.h
@@ -1343,7 +1343,6 @@ struct tds_socket
 	unsigned int emul_little_endian:1;
 	unsigned int use_iconv:1;
 	unsigned int tds71rev1:1;
-	unsigned int application_intent:1;
   
 	unsigned char *in_buf;		/**< input buffer */
 	unsigned char *out_buf;		/**< output buffer */

--- a/include/tdsodbc.h
+++ b/include/tdsodbc.h
@@ -467,7 +467,8 @@ BOOL get_login_info(HWND hwndParent, TDSCONNECTION * connection);
 	ODBC_PARAM(Trusted_Connection) \
 	ODBC_PARAM(APP) \
 	ODBC_PARAM(WSID) \
-	ODBC_PARAM(UseNTLMv2)
+	ODBC_PARAM(UseNTLMv2)\
+	ODBC_PARAM(ApplicationIntent)
 
 #define ODBC_PARAM(p) ODBC_PARAM_##p,
 enum {

--- a/src/odbc/connectparams.c
+++ b/src/odbc/connectparams.c
@@ -35,6 +35,7 @@
 
 #ifdef DMALLOC
 #include <dmalloc.h>
+#include "../../include/tds.h"
 #endif
 
 TDS_RCSID(var, "$Id: connectparams.c,v 1.88 2010-11-09 15:46:42 freddy77 Exp $");
@@ -382,6 +383,9 @@ odbc_parse_connect_string(TDS_ERRS *errs, const char *connect_string, const char
 			tds_parse_conf_section(TDS_STR_ENCRYPTION, tds_dstr_cstr(&value), connection);
 		} else if (CHK_PARAM(UseNTLMv2)) {
 			tds_parse_conf_section(TDS_STR_USENTLMV2, tds_dstr_cstr(&value), connection);
+		} else if (CHK_PARAM(ApplicationIntent)) {
+			tds_parse_conf_section(TDS_STR_APPLICATION_INTENT, tds_dstr_cstr(&value), connection);
+			tdsdump_log(TDS_DBG_INFO1, "Application Intent %s \n", tds_dstr_cstr(&value) );
 		} else if (CHK_PARAM(Trusted_Connection)) {
 			trusted = tds_config_boolean(tds_dstr_cstr(&value));
 			tdsdump_log(TDS_DBG_INFO1, "trusted %s -> %d\n", tds_dstr_cstr(&value), trusted);

--- a/src/odbc/connectparams.c
+++ b/src/odbc/connectparams.c
@@ -35,7 +35,6 @@
 
 #ifdef DMALLOC
 #include <dmalloc.h>
-#include "../../include/tds.h"
 #endif
 
 TDS_RCSID(var, "$Id: connectparams.c,v 1.88 2010-11-09 15:46:42 freddy77 Exp $");

--- a/src/tds/config.c
+++ b/src/tds/config.c
@@ -253,6 +253,7 @@ tds_read_config_info(TDSSOCKET * tds, TDSLOGIN * login, TDSLOCALE * locale)
 		tdsdump_log(TDS_DBG_INFO1, "\t%20s = %d\n", "broken_dates", connection->broken_dates);
 		tdsdump_log(TDS_DBG_INFO1, "\t%20s = %d\n", "emul_little_endian", connection->emul_little_endian);
 		tdsdump_log(TDS_DBG_INFO1, "\t%20s = %s\n", "server_realm_name", tds_dstr_cstr(&connection->server_realm_name));
+		tdsdump_log(TDS_DBG_INFO1, "\t%20s = %d\n", "application_intent", connection->application_intent);
 
 		tdsdump_close();
 	}
@@ -421,7 +422,7 @@ tds_read_conf_sections(FILE * in, const char *server, TDSCONNECTION * connection
 }
 
 static const struct {
-	char value[7];
+	char value[9];
 	unsigned char to_return;
 } boolean_values[] = {
 	{ "yes",	1 },
@@ -429,7 +430,9 @@ static const struct {
 	{ "on",		1 },
 	{ "off",	0 },
 	{ "true",	1 },
-	{ "false",	0 }
+	{ "false",	0 },
+	{ "ReadOnly", 1},
+	{ "ReadWrite", 0}
 };
 
 int
@@ -504,6 +507,7 @@ tds_read_conf_section(FILE * in, const char *section, TDSCONFPARSE tds_conf_pars
 			p = *s;
 			s++;
 		}
+		option[i] = '\0';
 
 		/* skip if empty option */
 		if (!i)
@@ -568,6 +572,7 @@ tds_parse_conf_section(const char *option, const char *value, void *param)
 
 	if (!strcmp(option, TDS_STR_VERSION)) {
 		tds_config_verstr(value, connection);
+		tdsdump_log(TDS_DBG_FUNC, "Setting TDS Version to  '%s' .\n", value);
 	} else if (!strcmp(option, TDS_STR_BLKSZ)) {
 		int val = atoi(value);
 		if (val >= 512 && val < 65536)
@@ -627,7 +632,11 @@ tds_parse_conf_section(const char *option, const char *value, void *param)
 		connection->use_ntlmv2 = tds_config_boolean(value);
 	} else if (!strcmp(option, TDS_STR_REALM)) {
 		tds_dstr_copy(&connection->server_realm_name, value);
-	} else {
+	} else if (!strcmp(option, TDS_STR_APPLICATION_INTENT)) {
+		connection->application_intent = tds_config_boolean(value);
+		tdsdump_log(TDS_DBG_FUNC, "Setting Application Intent to  '%s' .\n", value);
+	}
+	else {
 		tdsdump_log(TDS_DBG_INFO1, "UNRECOGNIZED option '%s' ... ignoring.\n", option);
 	}
 }
@@ -693,6 +702,9 @@ tds_config_login(TDSCONNECTION * connection, TDSLOGIN * login)
 
 	if (login->query_timeout)
 		connection->query_timeout = login->query_timeout;
+
+	if(login->application_intent)
+		connection->application_intent = login->application_intent;
 
 	/* copy other info not present in configuration file */
 	memcpy(connection->capabilities, login->capabilities, TDS_MAX_CAPABILITY);

--- a/src/tds/config.c
+++ b/src/tds/config.c
@@ -431,8 +431,8 @@ static const struct {
 	{ "off",	0 },
 	{ "true",	1 },
 	{ "false",	0 },
-	{ "ReadOnly", 1},
-	{ "ReadWrite", 0}
+	{ "ReadOnly",   1 },
+	{ "ReadWrite",  0 }
 };
 
 int
@@ -507,7 +507,6 @@ tds_read_conf_section(FILE * in, const char *section, TDSCONFPARSE tds_conf_pars
 			p = *s;
 			s++;
 		}
-		option[i] = '\0';
 
 		/* skip if empty option */
 		if (!i)
@@ -572,7 +571,6 @@ tds_parse_conf_section(const char *option, const char *value, void *param)
 
 	if (!strcmp(option, TDS_STR_VERSION)) {
 		tds_config_verstr(value, connection);
-		tdsdump_log(TDS_DBG_FUNC, "Setting TDS Version to  '%s' .\n", value);
 	} else if (!strcmp(option, TDS_STR_BLKSZ)) {
 		int val = atoi(value);
 		if (val >= 512 && val < 65536)

--- a/src/tds/login.c
+++ b/src/tds/login.c
@@ -397,8 +397,6 @@ tds_connect(TDSSOCKET * tds, TDSCONNECTION * connection, int *p_oserr)
 
 	tds->tds_version = connection->tds_version;
 	tds->emul_little_endian = connection->emul_little_endian;
-	tds->application_intent = connection->application_intent;
-	tdsdump_log(TDS_DBG_INFO1,"Application Intent Value is %d\n",tds->application_intent);
 #ifdef WORDS_BIGENDIAN
 	if (IS_TDS7_PLUS(tds)) {
 		/* TDS 7/8 only supports little endian */

--- a/src/tds/login.c
+++ b/src/tds/login.c
@@ -397,6 +397,8 @@ tds_connect(TDSSOCKET * tds, TDSCONNECTION * connection, int *p_oserr)
 
 	tds->tds_version = connection->tds_version;
 	tds->emul_little_endian = connection->emul_little_endian;
+	tds->application_intent = connection->application_intent;
+	tdsdump_log(TDS_DBG_INFO1,"Application Intent Value is %d\n",tds->application_intent);
 #ifdef WORDS_BIGENDIAN
 	if (IS_TDS7_PLUS(tds)) {
 		/* TDS 7/8 only supports little endian */
@@ -817,7 +819,7 @@ tds7_send_login(TDSSOCKET * tds, TDSCONNECTION * connection)
 
 	tds_put_byte(tds, option_flag2);
 
-	tds_put_byte(tds, sql_type_flag);
+	tds_put_byte(tds, connection->application_intent ? sql_type_flag|0x20 : sql_type_flag);
 	tds_put_byte(tds, reserved_flag);
 
 	tds_put_n(tds, time_zone, 4);


### PR DESCRIPTION
Implemented the "ApplicationIntent" property that is new in TDS 7.4 in the current stable version of "freetds_0.91".

You can use this by putting "ApplicationIntent=ReadOnly", in the connection string.
If you do not set this property the default value is ReadWrite, in which case the user can fire write queries too.
Remember to set the following as connection string if you want to do any WinAuth connections

"DRIVER=FreeTDS;Server=<IP>;Port=<PORT>;Database=<DB_NAME>;UID=<USERNAME>;PWD=<PASSWORD>;ApplicationIntent=<ReadWrite/ReadOnly>;TDS_Version=7.2;"

TODO:
Add test in the php/python.
Try to merge with the master branch and the current codeline.