### PR TITLE
Store the SPID value returned from the last seen TDS packet.

### DIFF
--- a/src/dblib/unittests/.gitignore
+++ b/src/dblib/unittests/.gitignore
@@ -41,3 +41,4 @@ setnull
 numeric
 pending
 cancel
+spid

--- a/src/dblib/unittests/Makefile.am
+++ b/src/dblib/unittests/Makefile.am
@@ -10,10 +10,10 @@ TESTS		=	t0001$(EXEEXT) t0002$(EXEEXT) t0003$(EXEEXT)\
 			done_handling$(EXEEXT) timeout$(EXEEXT) \
 			hang$(EXEEXT) null$(EXEEXT) null2$(EXEEXT) \
 			setnull$(EXEEXT) numeric$(EXEEXT) pending$(EXEEXT) \
-			cancel$(EXEEXT)
+			cancel$(EXEEXT) spid$(EXEEXT)
 check_PROGRAMS	=	$(TESTS)
 
-SQL_DIST = 	bcp.sql dbmorecmds.sql done_handling.sql rpc.sql \
+SQL_DIST = 	bcp.sql dbmorecmds.sql done_handling.sql rpc.sql spid.sql \
 		t0001.sql t0002.sql t0003.sql t0004.sql t0005.sql t0006.sql t0007.sql t0009.sql \
 		t0011.sql t0012.sql t0013.sql t0014.sql t0015.sql t0016.sql t0017.sql t0018.sql \
 		t0020.sql t0022.sql t0023.sql text_buffer.sql timeout.sql numeric.sql numeric_2.sql \
@@ -58,6 +58,7 @@ setnull_SOURCES	=	setnull.c common.c common.h
 numeric_SOURCES =	numeric.c common.c common.h
 pending_SOURCES =	pending.c common.c common.h
 cancel_SOURCES =	cancel.c common.c common.h
+spid_SOURCES =	spid.c common.c common.h
 
 AM_CPPFLAGS	= 	-DFREETDS_TOPDIR=\"$(top_srcdir)\" -I$(top_srcdir)/include
 if MINGW32

--- a/src/dblib/unittests/spid.c
+++ b/src/dblib/unittests/spid.c
@@ -1,0 +1,118 @@
+/*
+ * Purpose: Retrieve the connection SPID.
+ * Functions: dbspid
+ */
+
+#include "common.h"
+
+int failed = 0;
+
+
+int
+main(int argc, char **argv)
+{
+	LOGINREC *login;
+	DBPROCESS *dbproc;
+	DBINT expected_spid, actual_spid;
+    RETCODE erc;
+
+	set_malloc_options();
+
+	read_login_info(argc, argv);
+	if (argc > 1) {
+		argc -= optind;
+		argv += optind;
+	}
+
+	fprintf(stdout, "Starting %s\n", argv[0]);
+
+	/* Fortify_EnterScope(); */
+	dbinit();
+
+	dberrhandle(syb_err_handler);
+	dbmsghandle(syb_msg_handler);
+
+	fprintf(stdout, "About to logon as \"%s\"\n", USER);
+
+	login = dblogin();
+	DBSETLPWD(login, PASSWORD);
+	DBSETLUSER(login, USER);
+	DBSETLAPP(login, "t0001");
+
+	if (argc > 1) {
+        int i;
+		printf("server and login timeout overrides (%s and %s) detected\n", argv[0], argv[1]);
+		strcpy(SERVER, argv[0]);
+		i = atoi(argv[1]);
+		if (i) {
+			i = dbsetlogintime(i);
+			printf("dbsetlogintime returned %s.\n", (i == SUCCEED)? "SUCCEED" : "FAIL");
+		}
+	}
+
+	fprintf(stdout, "About to open \"%s\"\n", SERVER);
+
+	dbproc = dbopen(login, SERVER);
+	if (!dbproc) {
+		fprintf(stderr, "Unable to connect to %s\n", SERVER);
+		return 1;
+	}
+	dbloginfree(login);
+
+	fprintf(stdout, "Using database \"%s\"\n", DATABASE);
+	if (strlen(DATABASE)) {
+		erc = dbuse(dbproc, DATABASE);
+		assert(erc == SUCCEED);
+	}
+
+#ifdef DBQUOTEDIDENT
+	fprintf(stdout, "QUOTED_IDENTIFIER is %s\n", (dbisopt(dbproc, DBQUOTEDIDENT, NULL))? "ON":"OFF");
+#endif
+	sql_cmd(dbproc);
+	dbsqlexec(dbproc);
+
+	if (dbresults(dbproc) != SUCCEED) {
+		failed = 1;
+		fprintf(stderr, "error: expected a result set, none returned.\n");
+		exit(1);
+	}
+
+	if (SUCCEED != dbbind(dbproc, 1, INTBIND, -1, (BYTE *) & expected_spid)) {
+		failed = 1;
+		fprintf(stderr, "Had problem with bind\n");
+		abort();
+	}
+    if (REG_ROW != dbnextrow(dbproc)) {
+		failed = 1;
+		fprintf(stderr, "Failed.  Expected a row\n");
+		exit(1);
+	}
+    assert(expected_spid > 0);
+
+    actual_spid = dbspid(dbproc);
+	if (expected_spid != actual_spid) {
+		failed = 1;
+		fprintf(stderr, "Failed.  Expected spid to be %d, was %d\n", expected_spid, actual_spid);
+		abort();
+	}
+
+	if (dbnextrow(dbproc) != NO_MORE_ROWS) {
+		failed = 1;
+		fprintf(stderr, "Was expecting no more rows\n");
+		exit(1);
+	}
+
+    dbclose(dbproc);
+
+    actual_spid = dbspid(dbproc);
+    if (-1 != actual_spid) {
+        failed = 1;
+		fprintf(stderr, "Failed.  Expected spid to be -1, was %d\n", actual_spid);
+		abort();
+    }
+
+	dbexit();
+
+	fprintf(stdout, "%s %s\n", __FILE__, (failed ? "failed!" : "OK"));
+	return failed ? 1 : 0;
+}

--- a/src/dblib/unittests/spid.sql
+++ b/src/dblib/unittests/spid.sql
@@ -1,0 +1,2 @@
+select @@SPID;
+go

--- a/src/tds/packet.c
+++ b/src/tds/packet.c
@@ -634,6 +634,9 @@ tds_read_packet(TDSSOCKET * tds)
 	/* set the received packet type flag */
 	tds->in_flag = pkt[0];
 
+	/* set the spid */
+	tds->spid = TDS_GET_A2BE(pkt+4);
+
 	/* Set the length and pos (not sure what pos is used for now */
 	tds->in_len = p - pkt;
 	tds->in_pos = 8;


### PR DESCRIPTION
The SPID value wasn't working with the db-lib api dbspid() method. This value can be useful for debugging, so I add an implementation for it. The SPID value is pulled from the last seen TDS packet header. See https://msdn.microsoft.com/en-us/library/dd305266.aspx.

I don't have much experience in the code, so perhaps there is a more appropriate way to get this value?