### PR TITLE
Increased max database name length to 128

### DIFF
--- a/include/sybdb.h
+++ b/include/sybdb.h
@@ -61,7 +61,7 @@ extern "C"
 #define INT_TIMEOUT	3
 
 #define DBMAXNUMLEN 33
-#define DBMAXNAME   30
+#define DBMAXNAME   128     // https://msdn.microsoft.com/en-us/library/ms176061.aspx
 
 /**
  * DBVERSION_xxx are used with dbsetversion()


### PR DESCRIPTION
If a ‘USE <database name larger than 30 characters’ statement is executed,
the dbname function would be trimmed. 128 is based on the microsoft
create database docs.