### PR TITLE
Add dbgettimeout and dbsettimeout APIs

### DIFF
--- a/include/sybdb.h
+++ b/include/sybdb.h
@@ -826,6 +826,9 @@ int dbnumrets(DBPROCESS * dbproc);
 DBPROCESS *tdsdbopen(LOGINREC * login, const char *server, int msdblib);
 DBPROCESS *dbopen(LOGINREC * login, const char *server);
 
+RETCODE dbsettimeout(DBPROCESS * dbproc, int timeout);
+int dbgettimeout(DBPROCESS * dbproc);
+
 /* pivot functions */
 struct col_t;
 void dbpivot_count (struct col_t *output, const struct col_t *input);

--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -1300,6 +1300,37 @@ tdsdbopen(LOGINREC * login, const char *server, int msdblib)
 }
 
 /**
+ * \brief \c Set the query timeout for the connection.
+ *
+ * Set the query timeout for the connection, in seconds.
+ * \param dbproc contains all information needed by db-lib to manage communications with the server.
+ * \param timeout The query timeout, in seconds.
+ * \retval SUCCEED success.
+ * \retval FAIL dbsettimeout() failed.
+ */
+RETCODE dbsettimeout(DBPROCESS * dbproc, int timeout)
+{
+    CHECK_CONN(FAIL);
+	if (!dbproc->tds_socket)
+		return FAIL;
+    dbproc->tds_socket->query_timeout = timeout;
+    return SUCCEED;
+}
+
+/**
+ * \ingroup dblib_core
+ * \brief \c Get the query timeout for the connection.
+ *
+ * Get the query timeout for the connection, in seconds.
+ * \param dbproc contains all information needed by db-lib to manage communications with the server.
+ * \retval The query timeout in seconds, or -1 if dbproc is invalid.
+ */
+int dbgettimeout(DBPROCESS * dbproc)
+{
+    return (dbproc && dbproc->tds_socket) ? dbproc->tds_socket->query_timeout : -1;
+}
+
+/**
  * \ingroup dblib_core
  * \brief \c printf-like way to form SQL to send to the server.  
  *

--- a/src/dblib/unittests/.gitignore
+++ b/src/dblib/unittests/.gitignore
@@ -42,3 +42,4 @@ numeric
 pending
 cancel
 spid
+query_timeout

--- a/src/dblib/unittests/Makefile.am
+++ b/src/dblib/unittests/Makefile.am
@@ -10,10 +10,10 @@ TESTS		=	t0001$(EXEEXT) t0002$(EXEEXT) t0003$(EXEEXT)\
 			done_handling$(EXEEXT) timeout$(EXEEXT) \
 			hang$(EXEEXT) null$(EXEEXT) null2$(EXEEXT) \
 			setnull$(EXEEXT) numeric$(EXEEXT) pending$(EXEEXT) \
-			cancel$(EXEEXT) spid$(EXEEXT)
+			cancel$(EXEEXT) spid$(EXEEXT) query_timeout$(EXEEXT)
 check_PROGRAMS	=	$(TESTS)
 
-SQL_DIST = 	bcp.sql dbmorecmds.sql done_handling.sql rpc.sql spid.sql \
+SQL_DIST = 	bcp.sql dbmorecmds.sql done_handling.sql rpc.sql spid.sql query_timeout.sql \
 		t0001.sql t0002.sql t0003.sql t0004.sql t0005.sql t0006.sql t0007.sql t0009.sql \
 		t0011.sql t0012.sql t0013.sql t0014.sql t0015.sql t0016.sql t0017.sql t0018.sql \
 		t0020.sql t0022.sql t0023.sql text_buffer.sql timeout.sql numeric.sql numeric_2.sql \
@@ -59,6 +59,7 @@ numeric_SOURCES =	numeric.c common.c common.h
 pending_SOURCES =	pending.c common.c common.h
 cancel_SOURCES =	cancel.c common.c common.h
 spid_SOURCES	=	spid.c common.c common.h
+query_timeout_SOURCES = query_timeout.c common.c common.h
 
 AM_CPPFLAGS	= 	-DFREETDS_TOPDIR=\"$(top_srcdir)\" -I$(top_srcdir)/include
 if MINGW32

--- a/src/dblib/unittests/query_timeout.c
+++ b/src/dblib/unittests/query_timeout.c
@@ -1,0 +1,234 @@
+/*
+ * Purpose: Test setting of query timeouts on a per-connection basis.
+ * Functions:  dberrhandle, dbsettimeout, dbgettimeout
+ */
+
+#include "common.h"
+#include <time.h>
+
+int ntimeouts = 0, ncancels = 0;
+const int max_timeouts = 3, timeout_seconds = 1;
+time_t start_time;
+
+int timeout_err_handler(DBPROCESS * dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr);
+int chkintr(DBPROCESS * dbproc);
+int hndlintr(DBPROCESS * dbproc);
+
+#if !defined(SYBETIME)
+#define SYBETIME SQLETIME
+#define INT_TIMEOUT INT_CANCEL
+dbsetinterrupt(DBPROCESS *dbproc, void* hand, void* p) {}
+#endif
+
+int
+timeout_err_handler(DBPROCESS * dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr)
+{
+	/*
+	 * For server messages, cancel the query and rely on the
+	 * message handler to spew the appropriate error messages out.
+	 */
+	if (dberr == SYBESMSG)
+		return INT_CANCEL;
+
+	if (dberr == SYBETIME) {
+		fprintf(stderr, "%d timeouts received in %ld seconds, ", ++ntimeouts, (long int) (time(NULL) - start_time));
+		if (ntimeouts > max_timeouts) {
+			if (++ncancels > 1) {
+				fprintf(stderr, "could not timeout cleanly, breaking connection\n");
+				ncancels = 0;
+				return INT_CANCEL;
+			}
+			fprintf(stderr, "lost patience, cancelling (allowing 10 seconds)\n");
+			if (dbsettime(10) == FAIL)
+				fprintf(stderr, "... but dbsettime() failed in error handler\n");
+			return INT_TIMEOUT;
+		}
+		fprintf(stderr, "continuing to wait\n");
+		return INT_CONTINUE;
+	}
+
+	ntimeouts = 0; /* reset */
+
+	fprintf(stderr,
+		"DB-LIBRARY error (severity %d, dberr %d, oserr %d, dberrstr %s, oserrstr %s):\n",
+		severity, dberr, oserr, dberrstr ? dberrstr : "(null)", oserrstr ? oserrstr : "(null)");
+	fflush(stderr);
+
+	/*
+	 * If the dbprocess is dead or the dbproc is a NULL pointer and
+	 * we are not in the middle of logging in, then we need to exit.
+	 * We can't do anything from here on out anyway.
+	 * It's OK to end up here in response to a dbconvert() that
+	 * resulted in overflow, so don't exit in that case.
+	 */
+	if ((dbproc == NULL) || DBDEAD(dbproc)) {
+		if (dberr != SYBECOFL) {
+			fprintf(stderr, "error: dbproc (%p) is %s, goodbye\n",
+					dbproc, dbproc? (DBDEAD(dbproc)? "DEAD" : "OK") : "NULL");
+			exit(255);
+		}
+	}
+
+	return INT_CANCEL;
+}
+
+int
+chkintr(DBPROCESS * dbproc)
+{
+	printf("in chkintr, %ld seconds elapsed\n", (long int) (time(NULL) - start_time));
+	return FALSE;
+}
+
+int
+hndlintr(DBPROCESS * dbproc)
+{
+	printf("in hndlintr, %ld seconds elapsed\n", (long int) (time(NULL) - start_time));
+	return INT_CONTINUE;
+}
+
+int
+main(int argc, char **argv)
+{
+	LOGINREC *login;
+	DBPROCESS *dbproc;
+	int i,r, failed = 0;
+	RETCODE erc, row_code;
+	int num_resultset = 0;
+	char teststr[1024];
+
+	/*
+	 * Connect to server
+	 */
+	set_malloc_options();
+
+	read_login_info(argc, argv);
+
+	fprintf(stdout, "Starting %s\n", argv[0]);
+
+	dbinit();
+
+	dberrhandle(timeout_err_handler);
+	dbmsghandle(syb_msg_handler);
+
+	fprintf(stdout, "About to logon\n");
+
+	login = dblogin();
+	DBSETLPWD(login, PASSWORD);
+	DBSETLUSER(login, USER);
+	DBSETLAPP(login, "#timeout");
+
+	fprintf(stdout, "About to open %s.%s\n", SERVER, DATABASE);
+
+	/*
+	 * One way to test the login timeout is to connect to a discard server (grep discard /etc/services).
+	 * It's normally supported by inetd.
+	 */
+	printf ("using %d 1-second login timeouts\n", max_timeouts);
+	dbsetlogintime(1);
+
+	start_time = time(NULL);	/* keep track of when we started for reporting purposes */
+
+	if (NULL == (dbproc = dbopen(login, SERVER))){
+		fprintf(stderr, "Failed: dbopen\n");
+		exit(1);
+	}
+
+	printf ("connected.\n");
+
+	if (strlen(DATABASE))
+		dbuse(dbproc, DATABASE);
+
+	dbloginfree(login);
+
+    /* Set a very long global timeout. */
+    dbsettime(5 * 60);
+
+	/* send something that will take awhile to execute */
+	printf ("using %d %d-second query timeouts\n", max_timeouts, timeout_seconds);
+	if (FAIL == dbsettimeout(dbproc, timeout_seconds)) {
+		fprintf(stderr, "Failed: dbsettimeout\n");
+		exit(1);
+	}
+	printf ("issuing a query that will take 30 seconds\n");
+
+	if (FAIL == sql_cmd(dbproc)) {
+		fprintf(stderr, "Failed: dbcmd\n");
+		exit(1);
+	}
+
+	start_time = time(NULL);
+	ntimeouts = 0;
+	dbsetinterrupt(dbproc, (void*)chkintr, (void*)hndlintr);
+
+	if (FAIL == dbsqlsend(dbproc)) {
+		fprintf(stderr, "Failed: dbsend\n");
+		exit(1);
+	}
+
+	/* wait for it to execute */
+	printf("executing dbsqlok\n");
+	erc = dbsqlok(dbproc);
+	if (erc != FAIL) {
+		fprintf(stderr, "dbsqlok should fail for timeout\n");
+		exit(1);
+	}
+
+	/* retrieve outputs per usual */
+	r = 0;
+	for (i=0; (erc = dbresults(dbproc)) != NO_MORE_RESULTS; i++) {
+		int nrows, ncols;
+		switch (erc) {
+		case SUCCEED:
+			if (DBROWS(dbproc) == FAIL){
+				r++;
+				continue;
+			}
+			assert(DBROWS(dbproc) == SUCCEED);
+			printf("dbrows() returned SUCCEED, processing rows\n");
+
+			ncols = dbnumcols(dbproc);
+			++num_resultset;
+			printf("bound 1 of %d columns ('%s') in result %d.\n", ncols, dbcolname(dbproc, 1), ++r);
+			dbbind(dbproc, 1, STRINGBIND, 0, (BYTE *) teststr);
+
+			printf("\t%s\n\t-----------\n", dbcolname(dbproc, 1));
+			while ((row_code = dbnextrow(dbproc)) != NO_MORE_ROWS) {
+				if (row_code == REG_ROW) {
+					printf("\t%s\n", teststr);
+				} else {
+					/* not supporting computed rows in this unit test */
+					failed = 1;
+					fprintf(stderr, "Failed.  Expected a row\n");
+					exit(1);
+				}
+			}
+			nrows = (int) dbcount(dbproc);
+			printf("row count %d\n", nrows);
+			if (nrows < 0){
+				failed++;
+				printf("error: dbrows() returned SUCCEED, but dbcount() returned -1\n");
+			}
+
+            if (timeout_seconds != dbgettimeout(dbproc)) {
+                failed++;
+				printf("error: dbgettimeout(%p) returned unexpected value %d\n", dbproc, dbgettimeout(dbproc));
+            }
+			break;
+		case FAIL:
+			printf("dbresults returned FAIL\n");
+			exit(1);
+		default:
+			printf("unexpected return code %d from dbresults\n", erc);
+			exit(1);
+		}
+		if (i > 1) {
+			failed++;
+			break;
+		}
+	} /* while dbresults */
+
+	dbexit();
+
+	fprintf(stdout, "%s %s\n", __FILE__, (failed ? "failed!" : "OK"));
+	return failed ? 1 : 0;
+}

--- a/src/dblib/unittests/query_timeout.sql
+++ b/src/dblib/unittests/query_timeout.sql
@@ -1,0 +1,2 @@
+select getdate() as 'begintime' waitfor delay '00:00:30' select getdate() as 'endtime'
+go


### PR DESCRIPTION
These APIs read and write a tds socket query timeout and can be used to configure a per-connection query timeout instead of using the global timeout value that was set when the connection was created.