### PR TITLE
WIP: per-DBPROCESS query_timeout via setdbopt().

### DIFF
--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -4400,14 +4400,12 @@ dbsetopt(DBPROCESS * dbproc, int option, const char *char_param, int int_param)
 		return rc;
 		break;
 	case DBSETTIME:
-		/* dblib option */
 		if (char_param) {
-			int to;
-			to = atoi(char_param);
-			if (0 < to) {
+			i = atoi(char_param);
+			if (0 < i) {
 				rc = dbstring_assign(&(dbproc->dbopts[option].param), char_param);
 				if (rc == SUCCEED) {
-					dbproc->tds_socket->query_timeout = to;
+					dbproc->tds_socket->query_timeout = i;
 				}
 				return rc;
 			}
@@ -5934,7 +5932,6 @@ dbclropt(DBPROCESS * dbproc, int option, const char param[])
 		return SUCCEED;
 		break;
 	case DBSETTIME:
-		/* dblib option */
 		tds_mutex_lock(&dblib_mutex);
 		/*
 		 * Use global value of query timeout set by dbsettime() if any,

--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -5902,7 +5902,9 @@ dbclropt(DBPROCESS * dbproc, int option, const char param[])
 
 	tdsdump_log(TDS_DBG_FUNC, "dbclropt(%p, %d, %s)\n", dbproc, option, param);
 	CHECK_CONN(FAIL);
-	CHECK_NULP(param, "dbclropt", 3, FAIL);
+	if (option != DBSETTIME) {
+		CHECK_NULP(param, "dbclropt", 3, FAIL);
+	}
 
 	if ((option < 0) || (option >= DBNUMOPTIONS)) {
 		return FAIL;

--- a/src/dblib/unittests/.gitignore
+++ b/src/dblib/unittests/.gitignore
@@ -42,3 +42,4 @@ numeric
 pending
 cancel
 spid
+query_timeout

--- a/src/dblib/unittests/CMakeLists.txt
+++ b/src/dblib/unittests/CMakeLists.txt
@@ -4,7 +4,7 @@ foreach(target t0001 t0002 t0003 t0004 t0005 t0006 t0007 t0008 t0009
 	t0011 t0012 t0013 t0014 t0015 t0016 t0017 t0018 t0019 t0020
 	t0021 t0022 t0023 rpc dbmorecmds bcp thread text_buffer
 	done_handling timeout hang null null2 setnull numeric pending
-	cancel)
+	cancel query_timeout)
 	add_executable(d_${target} EXCLUDE_FROM_ALL ${target}.c)
 	set_target_properties(d_${target} PROPERTIES OUTPUT_NAME ${target})
 	target_link_libraries(d_${target} d_common sybdb replacements ${lib_NETWORK} ${lib_BASE})

--- a/src/dblib/unittests/Makefile.am
+++ b/src/dblib/unittests/Makefile.am
@@ -10,10 +10,10 @@ TESTS		=	t0001$(EXEEXT) t0002$(EXEEXT) t0003$(EXEEXT)\
 			done_handling$(EXEEXT) timeout$(EXEEXT) \
 			hang$(EXEEXT) null$(EXEEXT) null2$(EXEEXT) \
 			setnull$(EXEEXT) numeric$(EXEEXT) pending$(EXEEXT) \
-			cancel$(EXEEXT) spid$(EXEEXT)
+			cancel$(EXEEXT) spid$(EXEEXT) query_timeout$(EXEEXT)
 check_PROGRAMS	=	$(TESTS)
 
-SQL_DIST = 	bcp.sql dbmorecmds.sql done_handling.sql rpc.sql spid.sql \
+SQL_DIST = 	bcp.sql dbmorecmds.sql done_handling.sql rpc.sql spid.sql query_timeout.sql \
 		t0001.sql t0002.sql t0003.sql t0004.sql t0005.sql t0006.sql t0007.sql t0009.sql \
 		t0011.sql t0012.sql t0013.sql t0014.sql t0015.sql t0016.sql t0017.sql t0018.sql \
 		t0020.sql t0022.sql t0023.sql text_buffer.sql timeout.sql numeric.sql numeric_2.sql \
@@ -59,6 +59,7 @@ numeric_SOURCES =	numeric.c common.c common.h
 pending_SOURCES =	pending.c common.c common.h
 cancel_SOURCES =	cancel.c common.c common.h
 spid_SOURCES	=	spid.c common.c common.h
+query_timeout_SOURCES = query_timeout.c common.c common.h
 
 AM_CPPFLAGS	= 	-DFREETDS_TOPDIR=\"$(top_srcdir)\" -I$(top_srcdir)/include
 if MINGW32

--- a/src/dblib/unittests/query_timeout.c
+++ b/src/dblib/unittests/query_timeout.c
@@ -1,0 +1,226 @@
+/*
+ * Purpose: Test setting of query timeouts on a per-connection basis.
+ * Functions:  dberrhandle, dbsetopt, dbclropt, dbisopt
+ */
+
+#include "common.h"
+#include <time.h>
+
+int ntimeouts = 0, ncancels = 0;
+const int max_timeouts = 3;
+char timeout_seconds[] = "1";
+time_t start_time;
+
+int timeout_err_handler(DBPROCESS * dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr);
+int chkintr(DBPROCESS * dbproc);
+int hndlintr(DBPROCESS * dbproc);
+
+#if !defined(SYBETIME)
+#define SYBETIME SQLETIME
+#define INT_TIMEOUT INT_CANCEL
+dbsetinterrupt(DBPROCESS *dbproc, void* hand, void* p) {}
+#endif
+
+int
+timeout_err_handler(DBPROCESS * dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr)
+{
+	/*
+	 * For server messages, cancel the query and rely on the
+	 * message handler to spew the appropriate error messages out.
+	 */
+	if (dberr == SYBESMSG)
+		return INT_CANCEL;
+
+	if (dberr == SYBETIME) {
+		fprintf(stderr, "%d timeouts received in %ld seconds, ", ++ntimeouts, (long int) (time(NULL) - start_time));
+		if (ntimeouts > max_timeouts) {
+			if (++ncancels > 1) {
+				fprintf(stderr, "could not timeout cleanly, breaking connection\n");
+				ncancels = 0;
+				return INT_CANCEL;
+			}
+			fprintf(stderr, "lost patience, cancelling (allowing 10 seconds)\n");
+			if (dbsettime(10) == FAIL)
+				fprintf(stderr, "... but dbsettime() failed in error handler\n");
+			return INT_TIMEOUT;
+		}
+		fprintf(stderr, "continuing to wait\n");
+		return INT_CONTINUE;
+	}
+
+	ntimeouts = 0; /* reset */
+
+	fprintf(stderr,
+		"DB-LIBRARY error (severity %d, dberr %d, oserr %d, dberrstr %s, oserrstr %s):\n",
+		severity, dberr, oserr, dberrstr ? dberrstr : "(null)", oserrstr ? oserrstr : "(null)");
+	fflush(stderr);
+
+	/*
+	 * If the dbprocess is dead or the dbproc is a NULL pointer and
+	 * we are not in the middle of logging in, then we need to exit.
+	 * We can't do anything from here on out anyway.
+	 * It's OK to end up here in response to a dbconvert() that
+	 * resulted in overflow, so don't exit in that case.
+	 */
+	if ((dbproc == NULL) || DBDEAD(dbproc)) {
+		if (dberr != SYBECOFL) {
+			fprintf(stderr, "error: dbproc (%p) is %s, goodbye\n",
+					dbproc, dbproc? (DBDEAD(dbproc)? "DEAD" : "OK") : "NULL");
+			exit(255);
+		}
+	}
+
+	return INT_CANCEL;
+}
+
+int
+chkintr(DBPROCESS * dbproc)
+{
+	printf("in chkintr, %ld seconds elapsed\n", (long int) (time(NULL) - start_time));
+	return FALSE;
+}
+
+int
+hndlintr(DBPROCESS * dbproc)
+{
+	printf("in hndlintr, %ld seconds elapsed\n", (long int) (time(NULL) - start_time));
+	return INT_CONTINUE;
+}
+
+int
+main(int argc, char **argv)
+{
+	LOGINREC *login;
+	DBPROCESS *dbproc;
+	int i,r, failed = 0;
+	RETCODE erc, row_code;
+	int num_resultset = 0;
+	char teststr[1024];
+
+	/*
+	 * Connect to server
+	 */
+	set_malloc_options();
+
+	read_login_info(argc, argv);
+
+	fprintf(stdout, "Starting %s\n", argv[0]);
+
+	dbinit();
+
+	dberrhandle(timeout_err_handler);
+	dbmsghandle(syb_msg_handler);
+
+	fprintf(stdout, "About to logon\n");
+
+	login = dblogin();
+	DBSETLPWD(login, PASSWORD);
+	DBSETLUSER(login, USER);
+	DBSETLAPP(login, "#timeout");
+
+	fprintf(stdout, "About to open %s.%s\n", SERVER, DATABASE);
+
+	if (NULL == (dbproc = dbopen(login, SERVER))){
+		fprintf(stderr, "Failed: dbopen\n");
+		exit(1);
+	}
+
+	printf ("connected.\n");
+
+	if (strlen(DATABASE))
+		dbuse(dbproc, DATABASE);
+
+	dbloginfree(login);
+
+	/* Set a very long global timeout. */
+	dbsettime(5 * 60);
+
+	/* send something that will take awhile to execute */
+	printf ("using %d %s-second query timeouts\n", max_timeouts, timeout_seconds);
+	if (FAIL == dbsetopt(dbproc, DBSETTIME, timeout_seconds, 0)) {
+		fprintf(stderr, "Failed: dbsetopt(dbproc, DBSETTIME, \"%s\")\n", timeout_seconds);
+		exit(1);
+	}
+	printf ("issuing a query that will take 30 seconds\n");
+
+	if (FAIL == sql_cmd(dbproc)) {
+		fprintf(stderr, "Failed: dbcmd\n");
+		exit(1);
+	}
+
+	start_time = time(NULL);	/* keep track of when we started for reporting purposes */
+	ntimeouts = 0;
+	dbsetinterrupt(dbproc, (void*)chkintr, (void*)hndlintr);
+
+	if (FAIL == dbsqlsend(dbproc)) {
+		fprintf(stderr, "Failed: dbsend\n");
+		exit(1);
+	}
+
+	/* wait for it to execute */
+	printf("executing dbsqlok\n");
+	erc = dbsqlok(dbproc);
+	if (erc != FAIL) {
+		fprintf(stderr, "dbsqlok should fail for timeout\n");
+		exit(1);
+	}
+
+	/* retrieve outputs per usual */
+	r = 0;
+	for (i=0; (erc = dbresults(dbproc)) != NO_MORE_RESULTS; i++) {
+		int nrows, ncols;
+		switch (erc) {
+		case SUCCEED:
+			if (DBROWS(dbproc) == FAIL){
+				r++;
+				continue;
+			}
+			assert(DBROWS(dbproc) == SUCCEED);
+			printf("dbrows() returned SUCCEED, processing rows\n");
+
+			ncols = dbnumcols(dbproc);
+			++num_resultset;
+			printf("bound 1 of %d columns ('%s') in result %d.\n", ncols, dbcolname(dbproc, 1), ++r);
+			dbbind(dbproc, 1, STRINGBIND, 0, (BYTE *) teststr);
+
+			printf("\t%s\n\t-----------\n", dbcolname(dbproc, 1));
+			while ((row_code = dbnextrow(dbproc)) != NO_MORE_ROWS) {
+				if (row_code == REG_ROW) {
+					printf("\t%s\n", teststr);
+				} else {
+					/* not supporting computed rows in this unit test */
+					failed = 1;
+					fprintf(stderr, "Failed.  Expected a row\n");
+					exit(1);
+				}
+			}
+			nrows = (int) dbcount(dbproc);
+			printf("row count %d\n", nrows);
+			if (nrows < 0){
+				failed++;
+				printf("error: dbrows() returned SUCCEED, but dbcount() returned -1\n");
+			}
+
+			if (FAIL == dbclropt(dbproc, DBSETTIME, 0)) {
+				failed++;
+				printf("error: dbclropt(dbproc, DBSETTIME, ...) failed\n");
+			}
+			break;
+		case FAIL:
+			printf("dbresults returned FAIL\n");
+			exit(1);
+		default:
+			printf("unexpected return code %d from dbresults\n", erc);
+			exit(1);
+		}
+		if (i > 1) {
+			failed++;
+			break;
+		}
+	} /* while dbresults */
+
+	dbexit();
+
+	fprintf(stdout, "%s %s\n", __FILE__, (failed ? "failed!" : "OK"));
+	return failed ? 1 : 0;
+}

--- a/src/dblib/unittests/query_timeout.sql
+++ b/src/dblib/unittests/query_timeout.sql
@@ -1,0 +1,2 @@
+select getdate() as 'begintime' waitfor delay '00:00:30' select getdate() as 'endtime'
+go


### PR DESCRIPTION
See http://marc.info/?l=freetds&m=126037476326260

Note: This isn't tested yet. Just trying to see if the approach is sound and hopefully get some feedback.