### PR TITLE
Fisql performance issues

### DIFF
--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -2390,8 +2390,8 @@ dbconvert_ps(DBPROCESS * dbproc, int db_srctype, const BYTE * src, DBINT srclen,
 					ret = -1;
 				} else {
 					memcpy(dest, src, srclen);
-					for (i = srclen; i < destlen; i++)
-						dest[i] = ' ';
+					if (srclen < destlen)
+					    memset(dest + srclen, ' ', destlen - srclen);
 					ret = srclen;
 				}
 				break;
@@ -2532,8 +2532,8 @@ dbconvert_ps(DBPROCESS * dbproc, int db_srctype, const BYTE * src, DBINT srclen,
 			}
 			/* else pad with blanks */
 			memcpy(dest, dres.c, len);
-			for (i = len; i < destlen; i++)
-				dest[i] = ' ';
+			if(len < destlen)
+			    memset(dest+len, ' ', destlen - len);
 			ret = len;
 
 			break;


### PR DESCRIPTION
Hello,

I noticed that fisql is loosing quite a lot of time in padding spaces to varchar results. We could improve this by simply replacing for loop with memset. In my tests I got significant improvements in performance.
Tests were done on query that selects > 100 columns, 100K rows. Execution times in seconds:
for ~ 34s
memset - 11s

On my setup this difference was even bigger You compile freetds with -m64.

Feel free to drop me an email if You need more details.

Best Regards,
Wojciech Sztachanski

