### PR TITLE
Add unit tests for batch statements

### DIFF
--- a/src/dblib/unittests/.gitignore
+++ b/src/dblib/unittests/.gitignore
@@ -43,3 +43,5 @@ pending
 cancel
 spid
 canquery
+batch_stmt_ins_sel
+batch_stmt_ins_upd

--- a/src/dblib/unittests/CMakeLists.txt
+++ b/src/dblib/unittests/CMakeLists.txt
@@ -4,7 +4,7 @@ foreach(target t0001 t0002 t0003 t0004 t0005 t0006 t0007 t0008 t0009
 	t0011 t0012 t0013 t0014 t0015 t0016 t0017 t0018 t0019 t0020
 	t0021 t0022 t0023 rpc dbmorecmds bcp thread text_buffer
 	done_handling timeout hang null null2 setnull numeric pending
-	cancel spid canquery)
+	cancel spid canquery batch_stmt_ins_sel batch_stmt_ins_upd)
 	add_executable(d_${target} EXCLUDE_FROM_ALL ${target}.c)
 	set_target_properties(d_${target} PROPERTIES OUTPUT_NAME ${target})
 	target_link_libraries(d_${target} d_common sybdb replacements tdsutils ${lib_NETWORK} ${lib_BASE})

--- a/src/dblib/unittests/Makefile.am
+++ b/src/dblib/unittests/Makefile.am
@@ -36,7 +36,10 @@ TESTS =	\
 	pending$(EXEEXT) \
 	cancel$(EXEEXT) \
 	spid$(EXEEXT) \
-	canquery$(EXEEXT)
+	canquery$(EXEEXT) \
+	batch_stmt_ins_sel$(EXEEXT) \
+	batch_stmt_ins_upd$(EXEEXT)
+
 check_PROGRAMS	=	$(TESTS)
 
 SQL_DIST = 	bcp.sql dbmorecmds.sql done_handling.sql rpc.sql spid.sql \
@@ -45,7 +48,7 @@ SQL_DIST = 	bcp.sql dbmorecmds.sql done_handling.sql rpc.sql spid.sql \
 		t0020.sql t0022.sql t0023.sql text_buffer.sql timeout.sql numeric.sql numeric_2.sql \
 		pending.sql cancel.sql t0016_10.sql t0016_11.sql t0016_1.sql t0016_2.sql \
 		t0016_3.sql t0016_4.sql t0016_5.sql t0016_6.sql t0016_7.sql t0016_8.sql t0016_9.sql \
-		canquery.sql
+		canquery.sql batch_stmt_ins_sel.sql batch_stmt_ins_upd.sql
 
 noinst_SCRIPTS	= $(SQL_DIST)
 
@@ -73,7 +76,7 @@ t0022_SOURCES	=	t0022.c common.c common.h
 t0023_SOURCES	=	t0023.c common.c common.h
 rpc_SOURCES	=	rpc.c common.c common.h
 dbmorecmds_SOURCES =	dbmorecmds.c common.c common.h
-bcp_SOURCES	=	bcp.c bcp.h common.c common.h 
+bcp_SOURCES	=	bcp.c bcp.h common.c common.h
 thread_SOURCES	=	thread.c bcp.h common.c common.h
 text_buffer_SOURCES =	text_buffer.c common.c common.h
 done_handling_SOURCES =	done_handling.c common.c common.h
@@ -86,6 +89,8 @@ numeric_SOURCES =	numeric.c common.c common.h
 pending_SOURCES =	pending.c common.c common.h
 cancel_SOURCES =	cancel.c common.c common.h
 spid_SOURCES	=	spid.c common.c common.h
+batch_stmt_ins_sel_SOURCES	=	batch_stmt_ins_sel.c common.c common.h batch_stmt_ins_sel.sql
+batch_stmt_ins_upd_SOURCES	=	batch_stmt_ins_upd.c common.c common.h batch_stmt_ins_upd.sql
 canquery_SOURCES=	canquery.c common.c common.h
 
 AM_CPPFLAGS	= 	-DFREETDS_TOPDIR=\"$(top_srcdir)\" -I$(top_srcdir)/include
@@ -102,5 +107,5 @@ EXTRA_DIST	=	t0016.in t0017.in t0017.in.be data.bin CMakeLists.txt $(SQL_DIST) \
 CLEANFILES	=	tdsdump.out t0013.out t0014.out t0016.out \
 				t0016.err t0017.err t0017.out
 
-$(SQL_DIST): 
+$(SQL_DIST):
 	ln -s $(srcdir)/$@ .

--- a/src/dblib/unittests/batch_stmt_ins_sel.c
+++ b/src/dblib/unittests/batch_stmt_ins_sel.c
@@ -1,0 +1,262 @@
+/*
+ * Purpose: this will test what is returned from a batch of queries, some that return rows and some that do not
+ * This is related to a bug first identified in PHPs PDO library https://bugs.php.net/bug.php?id=72969
+ * Functions: dbbind dbcmd dbcolname dberrhandle dbisopt dbmsghandle dbnextrow dbnumcols dbopen dbresults dbsetlogintime dbsqlexec dbuse
+ */
+
+#include "common.h"
+
+
+static int failed = 0;
+
+int
+main(int argc, char **argv)
+{
+	LOGINREC *login;
+	DBPROCESS *dbproc;
+	int i;
+	DBINT erc;
+
+	RETCODE results_retcode;
+	int rowcount;
+	int colcount;
+	int row_retcode;
+
+	set_malloc_options();
+
+	read_login_info(argc, argv);
+	if (argc > 1) {
+		argc -= optind;
+		argv += optind;
+	}
+
+	printf("Starting %s\n", argv[0]);
+
+	/* Fortify_EnterScope(); */
+	dbinit();
+
+	dberrhandle(syb_err_handler);
+	dbmsghandle(syb_msg_handler);
+
+	printf("About to logon as \"%s\"\n", USER);
+
+	login = dblogin();
+	DBSETLPWD(login, PASSWORD);
+	DBSETLUSER(login, USER);
+	DBSETLAPP(login, "wf_dbresults");
+
+	if (argc > 1) {
+		printf("server and login timeout overrides (%s and %s) detected\n", argv[0], argv[1]);
+		strcpy(SERVER, argv[0]);
+		i = atoi(argv[1]);
+		if (i) {
+			i = dbsetlogintime(i);
+			printf("dbsetlogintime returned %s.\n", (i == SUCCEED) ? "SUCCEED" : "FAIL");
+		}
+	}
+
+	printf("About to open \"%s\"\n", SERVER);
+
+	dbproc = dbopen(login, SERVER);
+	if (!dbproc) {
+		fprintf(stderr, "Unable to connect to %s\n", SERVER);
+		return 1;
+	}
+	dbloginfree(login);
+
+	printf("Using database \"%s\"\n", DATABASE);
+	if (strlen(DATABASE)) {
+		erc = dbuse(dbproc, DATABASE);
+		assert(erc == SUCCEED);
+	}
+
+	sql_cmd(dbproc);
+	dbsqlexec(dbproc);
+	while (dbresults(dbproc) != NO_MORE_RESULTS) {
+		/* nop */
+	}
+
+	/*
+	 * This test is written to simulate how dblib is used in PDO
+	 * functions are called in the same order they would be if doing
+	 * PDO::query followed by some number of PDO::statement->nextRowset
+	 */
+
+	/*
+	 * First, call everything that happens in PDO::query
+	 * this will return the results of the CREATE TABLE statement
+	 */
+	dbcancel(dbproc);
+
+	printf("using sql_cmd\n");
+	sql_cmd(dbproc);
+	dbsqlexec(dbproc);
+
+	results_retcode = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("** CREATE TABLE **\n");
+	printf("RETCODE: %d\n", results_retcode);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	/* check that the results correspond to the create table statement */
+	assert(results_retcode == SUCCEED);
+	assert(rowcount == -1);
+	assert(colcount == 0);
+
+	/* now simulate calling nextRowset() for each remaining statement in our batch */
+
+	/*
+	 * INSERT
+	 */
+	printf("** INSERT **\n");
+
+	/* there shouldn't be any rows in this resultset yet, it's still from the CREATE TABLE */
+	row_retcode = dbnextrow(dbproc);
+	printf("dbnextrow retcode: %d\n", results_retcode);
+	assert(row_retcode == NO_MORE_ROWS);
+
+	results_retcode = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("RETCODE: %d\n", results_retcode);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	assert(results_retcode == SUCCEED);
+	assert(rowcount == 3);
+	assert(colcount == 0);
+
+	/*
+	 * SELECT
+	 */
+	printf("** SELECT **\n");
+
+	/* the rowset is still from the INSERT and should have no rows */
+	row_retcode = dbnextrow(dbproc);
+	printf("dbnextrow retcode: %d\n", results_retcode);
+	assert(row_retcode == NO_MORE_ROWS);
+
+	results_retcode = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("RETCODE: %d\n", results_retcode);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	assert(results_retcode == SUCCEED);
+	assert(rowcount == -1);
+	assert(colcount == 1);
+
+	/* now we expect to find three rows in the rowset */
+	row_retcode = dbnextrow(dbproc);
+	printf("dbnextrow retcode: %d\n", row_retcode);
+	assert(row_retcode == REG_ROW); // 4040 corresponds to TDS_ROW_RESULT in freetds/tds.h
+	row_retcode = dbnextrow(dbproc);
+	printf("dbnextrow retcode: %d\n", row_retcode);
+	assert(row_retcode == REG_ROW);
+	row_retcode = dbnextrow(dbproc);
+	printf("dbnextrow retcode: %d\n\n", row_retcode);
+	assert(row_retcode == REG_ROW);
+
+	/*
+	 * UPDATE
+	 */
+	printf("** UPDATE **\n");
+
+	/* check that there are no rows left, then we'll get the results from the UPDATE */
+	row_retcode = dbnextrow(dbproc);
+	printf("dbnextrow retcode: %d\n", row_retcode);
+	assert(row_retcode == NO_MORE_ROWS);
+
+	results_retcode = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("RETCODE: %d\n", results_retcode);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	assert(results_retcode == SUCCEED);
+	assert(rowcount == 3);
+	/*assert(colcount == 0); TODO: why does an update get a column? */
+
+	/*
+	 * SELECT
+	 */
+	printf("** SELECT **\n");
+
+	row_retcode = dbnextrow(dbproc);
+	printf("dbnextrow retcode: %d\n", row_retcode);
+	assert(row_retcode == NO_MORE_ROWS);
+
+	results_retcode = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("RETCODE: %d\n", results_retcode);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	assert(results_retcode == SUCCEED);
+	assert(rowcount == -1);
+	assert(colcount == 1);
+
+	/* now we expect to find three rows in the rowset again */
+	row_retcode = dbnextrow(dbproc);
+	printf("dbnextrow retcode: %d\n", row_retcode);
+	assert(row_retcode == REG_ROW);
+	row_retcode = dbnextrow(dbproc);
+	printf("dbnextrow retcode: %d\n", row_retcode);
+	assert(row_retcode == REG_ROW);
+	row_retcode = dbnextrow(dbproc);
+	printf("dbnextrow retcode: %d\n\n", row_retcode);
+	assert(row_retcode == REG_ROW);
+
+	/*
+	 * DROP
+	 */
+	printf("** DROP **\n");
+
+	row_retcode = dbnextrow(dbproc);
+	printf("dbnextrow retcode: %d\n", row_retcode);
+	assert(row_retcode == NO_MORE_ROWS);
+
+	results_retcode = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("RETCODE: %d\n", results_retcode);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	assert(results_retcode == SUCCEED);
+	assert(rowcount == -1);
+	/* assert(colcount == 0); */
+
+	/* Call one more time to be sure we get NO_MORE_RESULTS */
+	row_retcode = dbnextrow(dbproc);
+	printf("dbnextrow retcode: %d\n", row_retcode);
+	assert(row_retcode == NO_MORE_ROWS);
+
+	results_retcode = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("RETCODE: %d\n", results_retcode);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	assert(results_retcode == NO_MORE_RESULTS);
+	assert(rowcount == -1);
+	/* assert(colcount == 0); */
+
+	dbexit();
+
+	printf("%s %s\n", __FILE__, (failed ? "failed!" : "OK"));
+	return failed ? 1 : 0;
+}

--- a/src/dblib/unittests/batch_stmt_ins_sel.sql
+++ b/src/dblib/unittests/batch_stmt_ins_sel.sql
@@ -1,0 +1,17 @@
+create table #batch_stmt_ins_sel(id int);
+insert into #batch_stmt_ins_sel values(1), (2), (3);
+select * from #batch_stmt_ins_sel;
+update #batch_stmt_ins_sel set id = 4;
+select * from #batch_stmt_ins_sel;
+drop table #batch_stmt_ins_sel;
+create table #batch_stmt(id int)
+insert into #batch_stmt values(1)
+insert into #batch_stmt values(2)
+insert into #batch_stmt values(3)
+go
+create table #batch_stmt_ins_sel(id int)
+insert into #batch_stmt_ins_sel select id from #batch_stmt
+select * from #batch_stmt_ins_sel
+update #batch_stmt_ins_sel set id = 4
+select * from #batch_stmt_ins_sel
+drop table #batch_stmt_ins_sel

--- a/src/dblib/unittests/batch_stmt_ins_upd.c
+++ b/src/dblib/unittests/batch_stmt_ins_upd.c
@@ -1,0 +1,201 @@
+/*
+ * Purpose: this will test what is returned from a batch of queries that do not return any rows
+ * This is related to a bug first identified in PHPs PDO library https://bugs.php.net/bug.php?id=72969
+ * Functions: dbbind dbcmd dbcolname dberrhandle dbisopt dbmsghandle dbnextrow dbnumcols dbopen dbresults dbsetlogintime dbsqlexec dbuse
+ */
+
+#include "common.h"
+
+
+static int failed = 0;
+
+int
+main(int argc, char **argv)
+{
+	LOGINREC *login;
+	DBPROCESS *dbproc;
+	int i;
+	DBINT erc;
+
+	RETCODE ret;
+	int rowcount;
+	int colcount;
+
+	set_malloc_options();
+
+	read_login_info(argc, argv);
+	if (argc > 1) {
+		argc -= optind;
+		argv += optind;
+	}
+
+	printf("Starting %s\n", argv[0]);
+
+	/* Fortify_EnterScope(); */
+	dbinit();
+
+	dberrhandle(syb_err_handler);
+	dbmsghandle(syb_msg_handler);
+
+	printf("About to logon as \"%s\"\n", USER);
+
+	login = dblogin();
+	DBSETLPWD(login, PASSWORD);
+	DBSETLUSER(login, USER);
+	DBSETLAPP(login, "wf_dbresults");
+
+	if (argc > 1) {
+		printf("server and login timeout overrides (%s and %s) detected\n", argv[0], argv[1]);
+		strcpy(SERVER, argv[0]);
+		i = atoi(argv[1]);
+		if (i) {
+			i = dbsetlogintime(i);
+			printf("dbsetlogintime returned %s.\n", (i == SUCCEED) ? "SUCCEED" : "FAIL");
+		}
+	}
+
+	printf("About to open \"%s\"\n", SERVER);
+
+	dbproc = dbopen(login, SERVER);
+	if (!dbproc) {
+		fprintf(stderr, "Unable to connect to %s\n", SERVER);
+		return 1;
+	}
+	dbloginfree(login);
+
+	printf("Using database \"%s\"\n", DATABASE);
+	if (strlen(DATABASE)) {
+		erc = dbuse(dbproc, DATABASE);
+		assert(erc == SUCCEED);
+	}
+
+	sql_cmd(dbproc);
+	dbsqlexec(dbproc);
+	while (dbresults(dbproc) != NO_MORE_RESULTS) {
+		/* nop */
+	}
+
+ /*
+	* This test is written to simulate how dblib is used in PDO
+	* functions are called in the same order they would be if doing
+	* PDO::query followed by some number of PDO::statement->nextRowset
+	*/
+
+	/*
+	 * First, call everything that happens in PDO::query
+	 * this will return the results of the CREATE TABLE statement
+	 */
+	dbcancel(dbproc);
+
+	printf("using sql_cmd\n");
+	sql_cmd(dbproc);
+	dbsqlexec(dbproc);
+
+	ret = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("RETCODE: %d\n", ret);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	/* check the results of the create table statement */
+	assert(ret == SUCCEED);
+	assert(rowcount == -1);
+	assert(colcount == 0);
+
+	/* now simulate calling nextRowset() for each remaining statement in our batch */
+
+	/*
+	 * INSERT
+	 */
+	ret = dbnextrow(dbproc);
+	assert(ret == NO_MORE_ROWS);
+
+	ret = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("RETCODE: %d\n", ret);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	assert(ret == SUCCEED);
+	assert(rowcount == 3);
+	assert(colcount == 0);
+
+	/*
+	 * UPDATE
+	 */
+	ret = dbnextrow(dbproc);
+	assert(ret == NO_MORE_ROWS);
+
+	ret = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("RETCODE: %d\n", ret);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	assert(ret == SUCCEED);
+	assert(rowcount == 3);
+	assert(colcount == 0);
+
+	/*
+	 * INSERT
+	 */
+	ret = dbnextrow(dbproc);
+	assert(ret == NO_MORE_ROWS);
+
+	ret = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("RETCODE: %d\n", ret);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	assert(ret == SUCCEED);
+	assert(rowcount == 1);
+	assert(colcount == 0);
+
+	/*
+	 * DROP
+	 */
+	ret = dbnextrow(dbproc);
+	assert(ret == NO_MORE_ROWS);
+
+	ret = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("RETCODE: %d\n", ret);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	assert(ret == SUCCEED);
+	assert(rowcount == -1);
+	assert(colcount == 0);
+
+	/* Call one more time to be sure we get NO_MORE_RESULTS */
+	ret = dbnextrow(dbproc);
+	assert(ret == NO_MORE_ROWS);
+
+	ret = dbresults(dbproc);
+	rowcount = DBCOUNT(dbproc);
+	colcount = dbnumcols(dbproc);
+
+	printf("RETCODE: %d\n", ret);
+	printf("ROWCOUNT: %d\n", rowcount);
+	printf("COLCOUNT: %d\n\n", colcount);
+
+	assert(ret == NO_MORE_RESULTS);
+	assert(rowcount == -1);
+	assert(colcount == 0);
+
+	dbexit();
+
+	printf("%s %s\n", __FILE__, (failed ? "failed!" : "OK"));
+	return failed ? 1 : 0;
+}

--- a/src/dblib/unittests/batch_stmt_ins_upd.sql
+++ b/src/dblib/unittests/batch_stmt_ins_upd.sql
@@ -1,0 +1,15 @@
+create table #batch_stmt_results(id int);
+insert into #batch_stmt_results values(1), (2), (3);
+update #batch_stmt_results set id = 1;
+insert into #batch_stmt_results values(2);
+drop table #batch_stmt_results;
+create table #batch_stmt (id int)
+insert into #batch_stmt values(1)
+insert into #batch_stmt values(2)
+insert into #batch_stmt values(3)
+go
+create table #batch_stmt_results(id int)
+insert into #batch_stmt_results select id from #batch_stmt
+update #batch_stmt_results set id = 1
+insert into #batch_stmt_results values(2)
+drop table #batch_stmt_results


### PR DESCRIPTION
If you send a batch of statements in a single call to the database, and these statements don't return rows, the dbresults function doesn't process the data correctly. It will loop over all data the first time it is called and return to the calling function that there are no more rows.

Signed-off-by: Jeff Farr jefarr@wayfair.com