### PR TITLE
Batch statements without a select are not processed correctly.

### DIFF
--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -1767,6 +1767,8 @@ _dbresults(DBPROCESS * dbproc)
 					dbproc->dbresults_state = _DB_RES_NEXT_RESULT;
 					if (done_flags & TDS_DONE_ERROR)
 						return FAIL;
+					if (result_type == TDS_DONE_RESULT)
+						return SUCCEED;
 					break;
 
 				case _DB_RES_RESULTSET_EMPTY:


### PR DESCRIPTION
If you send a batch of statements in a single call to the database, and these statements don't return rows, the dbresults function doesn't process the data correctly. It will loop over all data the first time it is called and return to the calling function that there are no more rows.

Signed-off-by: Jeff Farr jefarr@wayfair.com