### PR TITLE
Do not override per-connection timeout settings in dbsettime

### DIFF
--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -4107,6 +4107,7 @@ dbsettime(int seconds)
 {
 	TDSSOCKET **tds;
 	int i;
+	DBPROCESS *dbproc;
 	tdsdump_log(TDS_DBG_FUNC, "dbsettime(%d)\n", seconds);
 
 	tds_mutex_lock(&dblib_mutex);
@@ -4114,8 +4115,11 @@ dbsettime(int seconds)
 	
 	tds = g_dblib_ctx.connection_list;
 	for (i = 0; i <  TDS_MAX_CONN; i++) {
-		if (tds[i])
-			tds[i]->query_timeout = seconds;
+		if (tds[i]) {
+			dbproc = (DBPROCESS *) tds_get_parent(tds[i]);
+			if (!dbisopt(dbproc, DBSETTIME, 0))
+				tds[i]->query_timeout = seconds;
+		}
 	}
 	
 	tds_mutex_unlock(&dblib_mutex);

--- a/src/dblib/unittests/timeout.c
+++ b/src/dblib/unittests/timeout.c
@@ -179,6 +179,9 @@ test(int per_process)
 			fprintf(stderr, "Failed: dbsetopt(..., DBSETTIME, \"%d\")\n", timeout_seconds);
 			exit(1);
 		}
+
+		/* Verify setting the global timeout won't override the per-process timeout value */
+		dbsettime(35);
 	} else {
 		if (FAIL == dbsettime(timeout_seconds)) {
 			fprintf(stderr, "Failed: dbsettime\n");


### PR DESCRIPTION
As per the discussion in https://github.com/FreeTDS/freetds/issues/105, calling `dbsettime(timeout)` should not override per-connection timeout settings previously set by `dbsetopt(connection, DBSETTIME, timeout, 0)`.