### PR TITLE
Changes to the TDS_ENCRYPTION_LEVEL enum

### DIFF
--- a/include/freetds/tds.h
+++ b/include/freetds/tds.h
@@ -330,9 +330,11 @@ typedef union tds_option_arg
 	TDS_CHAR *c;
 } TDS_OPTION_ARG;
 
-
 typedef enum tds_encryption_level {
-	TDS_ENCRYPTION_OFF, TDS_ENCRYPTION_REQUEST, TDS_ENCRYPTION_REQUIRE
+    TDS_ENCRYPTION_OFF           = 0x00,
+    TDS_ENCRYPTION_ON            = 0x01,
+    TDS_ENCRYPTION_NOT_SUPPORTED = 0x02,
+    TDS_ENCRYPTION_REQUIRE       = 0x03
 } TDS_ENCRYPTION_LEVEL;
 
 #define TDS_ZERO_FREE(x) do {free((x)); (x) = NULL;} while(0)

--- a/src/tds/config.c
+++ b/src/tds/config.c
@@ -474,15 +474,15 @@ tds_config_encryption(const char * value, TDSLOGIN * login)
 	if (!strcasecmp(value, TDS_STR_ENCRYPTION_OFF))
 		;
 	else if (!strcasecmp(value, TDS_STR_ENCRYPTION_REQUEST))
-		lvl = TDS_ENCRYPTION_REQUEST;
+		lvl = TDS_ENCRYPTION_ON;
 	else if (!strcasecmp(value, TDS_STR_ENCRYPTION_REQUIRE))
-		lvl = TDS_ENCRYPTION_REQUIRE;
+		lvl = TDS_ENCRYPTION_NOT_SUPPORTED;
 	else {
 		tdsdump_log(TDS_DBG_ERROR, "UNRECOGNIZED option value '%s' for '%s' setting!\n",
 			    value, TDS_STR_ENCRYPTION);
 		tdsdump_log(TDS_DBG_ERROR, "Valid settings are: ('%s', '%s', '%s')\n",
 		        TDS_STR_ENCRYPTION_OFF, TDS_STR_ENCRYPTION_REQUEST, TDS_STR_ENCRYPTION_REQUIRE);
-		lvl = TDS_ENCRYPTION_REQUIRE;  /* Assuming "require" is safer than "no" */
+		lvl = TDS_ENCRYPTION_NOT_SUPPORTED;  /* Assuming "require" is safer than "no" */
 		login->valid_configuration = 0;
 	}
 

--- a/src/tds/login.c
+++ b/src/tds/login.c
@@ -1128,9 +1128,9 @@ tds71_do_login(TDSSOCKET * tds, TDSLOGIN* login)
 	/* encryption */
 #if !defined(HAVE_GNUTLS) && !defined(HAVE_OPENSSL)
 	/* not supported */
-	tds_put_byte(tds, 2);
+	tds_put_byte(tds, TDS_ENCRYPTION_NOT_SUPPORTED);
 #else
-	tds_put_byte(tds, login->encryption_level >= TDS_ENCRYPTION_REQUIRE ? 1 : 0);
+	tds_put_byte(tds, login->encryption_level >= TDS_ENCRYPTION_NOT_SUPPORTED ? TDS_ENCRYPTION_ON : TDS_ENCRYPTION_OFF);
 #endif
 	/* instance */
 	tds_put_n(tds, instance_name, instance_name_len);
@@ -1189,9 +1189,9 @@ tds71_do_login(TDSSOCKET * tds, TDSLOGIN* login)
 	tdsdump_log(TDS_DBG_INFO1, "detected flag %d\n", crypt_flag);
 
 	/* if server do not has certificate do normal login */
-	if (crypt_flag == 2) {
+	if (crypt_flag == TDS_ENCRYPTION_NOT_SUPPORTED) {
 		/* unless we wanted encryption and got none, then fail */
-		if (login->encryption_level >= TDS_ENCRYPTION_REQUIRE)
+		if (login->encryption_level >= TDS_ENCRYPTION_NOT_SUPPORTED)
 			return TDS_FAIL;
 
 		return tds7_send_login(tds, login);
@@ -1211,7 +1211,7 @@ tds71_do_login(TDSSOCKET * tds, TDSLOGIN* login)
 	ret = tds7_send_login(tds, login);
 
 	/* if flag is 0 it means that after login server continue not encrypted */
-	if (crypt_flag == 0 || TDS_FAILED(ret))
+	if (crypt_flag == TDS_ENCRYPTION_OFF || TDS_FAILED(ret))
 		tds_ssl_deinit(tds->conn);
 
 	return ret;


### PR DESCRIPTION
Changes to the TDS_ENCRYPTION_LEVEL enum to match the values specified in https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-TDS/%5BMS-TDS%5D-160714.pdf. Precursor checkin with plans to add dblib option for specifying crypt level.