### PR TITLE
Fix the bug where encryption = off was treated like encryption = request

### DIFF
--- a/doc/freetds.conf.5.in
+++ b/doc/freetds.conf.5.in
@@ -102,9 +102,9 @@ no
 .It encryption
 .Bl -tag -compact
 .It Em off
-disables encryption (default)
+disables encryption
 .It Em request
-use if available
+use if available (default)
 .It Em required
 allow encrypted connections only
 .El

--- a/doc/userguide.sgml
+++ b/doc/userguide.sgml
@@ -1154,8 +1154,8 @@ This is the name of the database container in the server you are connecting to.<
 						<row>
 							<entry><literal>encryption</></entry>
 							<entry>off/request/require</entry>
-							<entry>off</entry>
-							<entry>Specify if encryption is desired. Supported for Microsoft servers. <symbol>off</> disables encryption (only if needed); <symbol>request</> means use if available; <symbol>require</> means create and allow encrypted connections only.</entry>
+							<entry>request</entry>
+							<entry>Specify if encryption is desired. Supported for Microsoft servers. <symbol>off</> disables encryption; <symbol>request</> means use if available; <symbol>require</> means create and allow encrypted connections only.</entry>
 							</row>
 						<row>
 							<entry><literal>enable gssapi delegation</></entry>

--- a/src/tds/config.c
+++ b/src/tds/config.c
@@ -466,10 +466,10 @@ tds_config_boolean(const char *option, const char *value, TDSLOGIN *login)
 static void
 tds_config_encryption(const char * value, TDSLOGIN * login)
 {
-	TDS_ENCRYPTION_LEVEL lvl = TDS_ENCRYPTION_REQUEST;
+	TDS_ENCRYPTION_LEVEL lvl = TDS_ENCRYPTION_OFF;
 
 	if (!strcasecmp(value, TDS_STR_ENCRYPTION_OFF))
-		lvl = TDS_ENCRYPTION_OFF;
+		;
 	else if (!strcasecmp(value, TDS_STR_ENCRYPTION_REQUEST))
 		lvl = TDS_ENCRYPTION_REQUEST;
 	else if (!strcasecmp(value, TDS_STR_ENCRYPTION_REQUIRE))

--- a/src/tds/config.c
+++ b/src/tds/config.c
@@ -466,10 +466,10 @@ tds_config_boolean(const char *option, const char *value, TDSLOGIN *login)
 static void
 tds_config_encryption(const char * value, TDSLOGIN * login)
 {
-	TDS_ENCRYPTION_LEVEL lvl = TDS_ENCRYPTION_OFF;
+	TDS_ENCRYPTION_LEVEL lvl = TDS_ENCRYPTION_REQUEST;
 
 	if (!strcasecmp(value, TDS_STR_ENCRYPTION_OFF))
-		;
+		lvl = TDS_ENCRYPTION_OFF;
 	else if (!strcasecmp(value, TDS_STR_ENCRYPTION_REQUEST))
 		lvl = TDS_ENCRYPTION_REQUEST;
 	else if (!strcasecmp(value, TDS_STR_ENCRYPTION_REQUIRE))

--- a/src/tds/login.c
+++ b/src/tds/login.c
@@ -1126,7 +1126,7 @@ tds71_do_login(TDSSOCKET * tds, TDSLOGIN* login)
 	/* not supported */
 	tds_put_byte(tds, 2);
 #else
-	tds_put_byte(tds, login->encryption_level >= TDS_ENCRYPTION_REQUIRE ? 1 : 0);
+	tds_put_byte(tds, login->encryption_level == TDS_ENCRYPTION_OFF ? 2 : login->encryption_level >= TDS_ENCRYPTION_REQUIRE ? 1 : 0);
 #endif
 	/* instance */
 	tds_put_n(tds, instance_name, instance_name_len);

--- a/src/tds/mem.c
+++ b/src/tds/mem.c
@@ -962,6 +962,7 @@ tds_alloc_login(int use_environment)
 	TEST_MALLOC(login, TDSLOGIN);
 	login->check_ssl_hostname = 1;
 	login->use_utf16 = 1;
+	login->encryption_level = TDS_ENCRYPTION_REQUEST;
 	tds_dstr_init(&login->server_name);
 	tds_dstr_init(&login->language);
 	tds_dstr_init(&login->server_charset);


### PR DESCRIPTION
Also change the default to encryption = request so that existing users of encryption
will not see encryption turned off.

For https://github.com/FreeTDS/freetds/issues/110

This was the simple way to fix this problem, just be inspecting the obvious intention of the code
and without reference to outside reference documents. 

Let me explain the source to the bug and why I fixed it the way I did. A customer upgraded
to the new freetds package, but built it from source under new conditions where HAVE_OPENSSL
was defined. But the previous freetds package was configured without openssl devel libraries present.

Then the behavior of his system suddenly changed, due to the extra cost of negotiating
the TSL handshake on login.  To fix this I read the documentation and edited /etc/freetds.conf
to turn encryption = off; But that did not do anything.

The fix in the code for login.c was obvious. Treat encryption = off the same way as it would be treated if the software had not been built with HAVE_OPENSSL defined.

Now my pull requests appears to conflict with another pull requests for the same issue which makes
reference to documentation I have not read in detail. But I think if he changes his request
to also respond the comment about avoiding changes to default behavior, and
also updating the documentation, then the other request might address the issue fully.