### PR TITLE
Fix the bug where encryption = off was treated like encryption = request

### DIFF
--- a/doc/freetds.conf.5.in
+++ b/doc/freetds.conf.5.in
@@ -102,9 +102,9 @@ no
 .It encryption
 .Bl -tag -compact
 .It Em off
-disables encryption (default)
+disables encryption
 .It Em request
-use if available
+use if available (default when tds version greater than 7.0)
 .It Em required
 allow encrypted connections only
 .El

--- a/doc/userguide.sgml
+++ b/doc/userguide.sgml
@@ -1154,8 +1154,8 @@ This is the name of the database container in the server you are connecting to.<
 						<row>
 							<entry><literal>encryption</></entry>
 							<entry>off/request/require</entry>
-							<entry>off</entry>
-							<entry>Specify if encryption is desired. Supported for Microsoft servers. <symbol>off</> disables encryption (only if needed); <symbol>request</> means use if available; <symbol>require</> means create and allow encrypted connections only.</entry>
+							<entry>request (if tds version &gt= 7.1 otherwise off)</entry>
+							<entry>Specify if encryption is desired. Supported for Microsoft servers. <symbol>off</> disables encryption; <symbol>request</> means use if available; <symbol>require</> means create and allow encrypted connections only.</entry>
 							</row>
 						<row>
 							<entry><literal>enable gssapi delegation</></entry>

--- a/src/tds/login.c
+++ b/src/tds/login.c
@@ -1142,8 +1142,15 @@ tds71_do_login(TDSSOCKET * tds, TDSLOGIN* login)
 	/* not supported */
 	tds_put_byte(tds, TDS7_ENCRYPT_NOT_SUP);
 #else
-	tds_put_byte(tds, login->encryption_level >= TDS_ENCRYPTION_REQUIRE ?
-		     TDS7_ENCRYPT_ON : TDS7_ENCRYPT_OFF);
+	/* The observation working with Microsoft SQL Server is that
+	   OFF did not mean off, and you would end up with encryption
+	   turned on. Therefore when the freetds.conf says encrypt = off
+	   we really want no encryption, and claiming lack of support
+	   works for that. Note that the configuration default in this
+	   subroutine always been request due to code above that
+	   tests for TDS_ENCRYPTION_DEFAULT.
+	*/
+	tds_put_byte(tds, login->encryption_level == TDS_ENCRYPTION_OFF ? TDS7_ENCRYPT_NOT_SUP : login->encryption_level >= TDS_ENCRYPTION_REQUIRE ? TDS7_ENCRYPT_ON : TDS7_ENCRYPT_OFF);
 #endif
 	/* instance */
 	tds_put_n(tds, instance_name, instance_name_len);


### PR DESCRIPTION
in the freetds.conf Also updated the documentation to describe
how the encryption default depends on the tds version. Existing users
of encryption should be ok, since TDS_ENCRYPTION_DEFAULT always becomes
either TDS_ENCRYPTION_OFF or TDS_ENCRYPTION_REQUEST.

For https://github.com/FreeTDS/freetds/issues/110