### PR TITLE
In `ct_options`, set the tds_argsize to 1 for CS_OPT_ARITHIGNORE.

### DIFF
--- a/src/ctlib/ct.c
+++ b/src/ctlib/ct.c
@@ -3539,8 +3539,8 @@ ct_options(CS_CONNECTION * con, CS_INT action, CS_INT option, CS_VOID * param, C
 			if (action == CS_SET)
 				return CS_FAIL;
 		}
-		tds_argument.i = TDS_OPT_ARITHOVERFLOW | TDS_OPT_NUMERICTRUNC;
-		tds_argsize = (action == CS_SET) ? 4 : 0;
+		tds_argument.ti = TDS_OPT_ARITHOVERFLOW | TDS_OPT_NUMERICTRUNC;
+		tds_argsize = (action == CS_SET) ? 1 : 0;
 		break;
 	case CS_OPT_AUTHOFF:
 		tds_option = TDS_OPT_AUTHOFF;


### PR DESCRIPTION
I am encountering errors when calling `ct_options` with `CS_OPT_ARITHIGNORE`.  Sybase server 15.7 is returning:

    Sybase Message: Severity 18, Error 3805, State 1

    The token datastream length was not correct. This is an internal
    protocol error.

It seems that `tds_argsize` is set to 4 when my server is expecting it to be 1. This patch changes that.