### PR TITLE
tds: Escape left brace in regex in encodings.pl

### DIFF
--- a/src/tds/encodings.pl
+++ b/src/tds/encodings.pl
@@ -9,7 +9,7 @@ $srcdir = "$ARGV[0]/";
 $filename = "${srcdir}alternative_character_sets.h";
 open ALT, $filename or die qq($basename: could not open "$filename"\n);
 while(<ALT>){
-	next unless /^\t[, ] {\s+"(.+?)", "(.+?)"/;
+	next unless /^\t[, ] \{\s+"(.+?)", "(.+?)"/;
 	$alternates{$2} = $1;
 }
 close ALT;


### PR DESCRIPTION
Since Perl v5.22.0, unescaped left braces ('{') in regexes are deprecated; since Perl v5.26.0, they are forbidden in most cases. Escape such a case in encodings.pl using a backslash.

(I am currently hunting down a case of memory corruption in `fisql`, but found this change necessary for FreeTDS to build.)