### PR TITLE
Fix out-of-tree build on MINGW.

### DIFF
--- a/src/odbc/Makefile.am
+++ b/src/odbc/Makefile.am
@@ -18,7 +18,7 @@ endif
 
 if MINGW32
 libtdsodbc_la_LIBADD +=	setup.res
-libtdsodbc_la_LDFLAGS += -Wl,--kill-at -Wl,--enable-stdcall-fixup -Wl,-s -Wl,odbc_w.def -Wl,setup.res
+libtdsodbc_la_LDFLAGS += -Wl,--kill-at -Wl,--enable-stdcall-fixup -Wl,-s -Wl,@srcdir@/odbc_w.def -Wl,setup.res
 
 .rc.res:
 	$(RC) -i $< --input-format=rc -o $@ -O coff


### PR DESCRIPTION
[MSYS2](http://msys2.org) builds packages out-of-tree. This currently fails because `odbc_w.def` can not be found in the build directory.

Therefore I added this patch in the build script for a FreeTDS build script here: https://github.com/Alexpux/MINGW-packages/pull/2671