### PR TITLE
Enable inet_pton() definition in MINGW i686 build

### DIFF
--- a/src/tds/tls.c
+++ b/src/tds/tls.c
@@ -20,6 +20,9 @@
 
 #include <config.h>
 
+/* enabled some additional definitions for inet_pton */
+#define _WIN32_WINNT 0x601
+
 #include <stdio.h>
 
 #if HAVE_ERRNO_H


### PR DESCRIPTION
inet_pton() is not included by default in i686 build, because it was new in Windows Vista.

This fixes the issue very similar to getaddrinfo() in sspi.c.

This patch is part of https://github.com/Alexpux/MINGW-packages/pull/2671 .
With this patch (and an autoconf related patch) the build succeeds on Appveyor for i686 and x86_64: https://ci.appveyor.com/project/Alexpux/mingw-packages/build/1.0.3267