### PR TITLE
Update CMakeLists.txt to define INSTALL files, targets... in Windows Systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,15 +474,15 @@ set(FREETDS_PUBLIC_INCLUDE
         ${CMAKE_SOURCE_DIR}/include/sybdb.h
 		${CMAKE_SOURCE_DIR}/include/sybfront.h 
         ${CMAKE_SOURCE_DIR}/include/syberror.h
-		${CMAKE_SOURCE_DIR}/include/odbcss.h
-		${CMAKE_BINARY_DIR}/include/tds_sysdep_public.h)
+		${CMAKE_SOURCE_DIR}/include/odbcss.h)
 
 set(FREETDS_PUBLIC_INCLUDE_2 
 		${CMAKE_BINARY_DIR}/include/freetds/version.h)
 
 set(FREETDS_CONF_FILES 
 		${CMAKE_SOURCE_DIR}/freetds.conf
-		${CMAKE_SOURCE_DIR}/locales.conf)
+		${CMAKE_SOURCE_DIR}/locales.conf
+		${CMAKE_SOURCE_DIR}/src/pool/pool.conf)
 		
 install(FILES ${FREETDS_PUBLIC_INCLUDE} DESTINATION include)
 install(FILES ${FREETDS_PUBLIC_INCLUDE_2} DESTINATION include/freetds)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,3 +461,30 @@ configure_file(${CMAKE_SOURCE_DIR}/include/freetds/version.h.in ${CMAKE_BINARY_D
 if(NOT EXISTS "${CMAKE_SOURCE_DIR}/configure")
 	configure_file(${CMAKE_SOURCE_DIR}/src/odbc/version.rc.in ${CMAKE_SOURCE_DIR}/src/odbc/version.rc)
 endif(NOT EXISTS "${CMAKE_SOURCE_DIR}/configure")
+
+
+if(WIN32)
+set(FREETDS_PUBLIC_INCLUDE 
+		${CMAKE_SOURCE_DIR}/include/bkpublic.h
+        ${CMAKE_SOURCE_DIR}/include/cspublic.h
+        ${CMAKE_SOURCE_DIR}/include/cstypes.h
+        ${CMAKE_SOURCE_DIR}/include/ctpublic.h
+		${CMAKE_SOURCE_DIR}/include/sqldb.h
+		${CMAKE_SOURCE_DIR}/include/sqlfront.h
+        ${CMAKE_SOURCE_DIR}/include/sybdb.h
+		${CMAKE_SOURCE_DIR}/include/sybfront.h 
+        ${CMAKE_SOURCE_DIR}/include/syberror.h
+		${CMAKE_SOURCE_DIR}/include/odbcss.h
+		${CMAKE_BINARY_DIR}/include/tds_sysdep_public.h)
+
+set(FREETDS_PUBLIC_INCLUDE_2 
+		${CMAKE_BINARY_DIR}/include/freetds/version.h)
+
+set(FREETDS_CONF_FILES 
+		${CMAKE_SOURCE_DIR}/freetds.conf
+		${CMAKE_SOURCE_DIR}/locales.conf)
+		
+install(FILES ${FREETDS_PUBLIC_INCLUDE} DESTINATION include)
+install(FILES ${FREETDS_PUBLIC_INCLUDE_2} DESTINATION include/freetds)
+install(FILES ${FREETDS_CONF_FILES} DESTINATION etc)
+endif(WIN32)

--- a/include/cstypes.h
+++ b/include/cstypes.h
@@ -140,6 +140,9 @@ typedef CS_INT CS_DATE;
 
 typedef CS_INT CS_TIME;
 
+typedef CS_UBIGINT CS_BIGDATETIME;
+typedef CS_UBIGINT CS_BIGTIME;
+
 typedef struct _cs_datetime
 {
 	CS_INT dtdays;

--- a/include/freetds/bool.h
+++ b/include/freetds/bool.h
@@ -31,7 +31,8 @@
 #undef true
 #undef false
 #undef bool
-#define bool int
+typedef unsigned char freetds_boolean_t;
+#define bool freetds_boolean_t
 #define true 1
 #define false 0
 

--- a/include/freetds/configs.h
+++ b/include/freetds/configs.h
@@ -25,7 +25,7 @@
 #include <freetds/sysconfdir.h>
 
 #ifndef _tds_h_
-#error tds.h must be included before tds_configs.h
+#error freetds/tds.h must be included before freetds/configs.h
 #endif
 
 #ifdef __cplusplus

--- a/include/freetds/tds.h
+++ b/include/freetds/tds.h
@@ -1192,8 +1192,8 @@ struct tds_socket
 	TDSCOMPUTEINFO **comp_info;
 	TDSPARAMINFO *param_info;
 	TDSCURSOR *cur_cursor;		/**< cursor in use */
-	TDS_TINYINT bulk_query;		/**< true is query sent was a bulk query so we need to switch state to QUERYING */
-	TDS_TINYINT has_status; 	/**< true is ret_status is valid */
+	bool bulk_query;		/**< true is query sent was a bulk query so we need to switch state to QUERYING */
+	bool has_status; 		/**< true is ret_status is valid */
 	TDS_INT ret_status;     	/**< return status from store procedure */
 	TDS_STATE state;
 	volatile 

--- a/include/freetds/tds.h
+++ b/include/freetds/tds.h
@@ -345,9 +345,7 @@ typedef enum tds_encryption_level {
           ((((unsigned long)value)>> 8) & 0x0000FF00)  | \
           ((((unsigned long)value)>>24) & 0x000000FF))
 
-#define is_end_token(x) (x==TDS_DONE_TOKEN    || \
-			x==TDS_DONEPROC_TOKEN    || \
-			x==TDS_DONEINPROC_TOKEN)
+#define is_end_token(x) ((x) >= TDS_DONE_TOKEN && (x) <= TDS_DONEINPROC_TOKEN)
 
 enum {
 	TDS_TYPEFLAG_INVALID  = 0,

--- a/include/freetds/tds.h
+++ b/include/freetds/tds.h
@@ -776,9 +776,9 @@ typedef struct tds_result_info
 
 	TDS_SMALLINT *bycolumns;
 	TDS_USMALLINT by_cols;
-	TDS_TINYINT rows_exist;
+	bool rows_exist;
 	/* TODO remove ?? used only in dblib */
-	TDS_TINYINT more_results;
+	bool more_results;
 } TDSRESULTINFO;
 
 /** values for tds->state */
@@ -940,7 +940,7 @@ typedef struct tds_cursor
 	/**
 	 * true if cursor was marker to be closed when connection is idle
 	 */
-	TDS_TINYINT defer_close;
+	bool defer_close;
 	char *query;                 	/**< SQL query */
 	/* TODO for updatable columns */
 	/* TDS_TINYINT number_upd_cols; */	/**< number of updatable columns */
@@ -991,7 +991,7 @@ typedef struct tds_dynamic
 	/**
 	 * true if dynamic was marker to be closed when connection is idle
 	 */
-	TDS_TINYINT defer_close;
+	bool defer_close;
 	/* int dyn_state; */ /* TODO use it */
 	TDSPARAMINFO *res_info;	/**< query results */
 	/**
@@ -1318,7 +1318,7 @@ void tds_deinit_bcpinfo(TDSBCPINFO *bcpinfo);
 void tds_set_packet(TDSLOGIN * tds_login, int packet_size);
 void tds_set_port(TDSLOGIN * tds_login, int port);
 bool tds_set_passwd(TDSLOGIN * tds_login, const char *password) TDS_WUR;
-void tds_set_bulk(TDSLOGIN * tds_login, TDS_TINYINT enabled);
+void tds_set_bulk(TDSLOGIN * tds_login, bool enabled);
 bool tds_set_user(TDSLOGIN * tds_login, const char *username) TDS_WUR;
 bool tds_set_app(TDSLOGIN * tds_login, const char *application) TDS_WUR;
 bool tds_set_host(TDSLOGIN * tds_login, const char *hostname) TDS_WUR;

--- a/include/freetds/tds.h
+++ b/include/freetds/tds.h
@@ -1192,6 +1192,7 @@ struct tds_socket
 	TDSCURSOR *cur_cursor;		/**< cursor in use */
 	bool bulk_query;		/**< true is query sent was a bulk query so we need to switch state to QUERYING */
 	bool has_status; 		/**< true is ret_status is valid */
+	bool in_row;			/**< true if we are getting rows */
 	TDS_INT ret_status;     	/**< return status from store procedure */
 	TDS_STATE state;
 	volatile 

--- a/include/freetds/tds.h
+++ b/include/freetds/tds.h
@@ -336,14 +336,14 @@ typedef enum tds_encryption_level {
  * check if unaligned access and use fast write/read when implemented
  */
 #define TDS_BYTE_SWAP16(value)                 \
-         (((((unsigned short)value)<<8) & 0xFF00)   | \
-          ((((unsigned short)value)>>8) & 0x00FF))
+         (((((uint16_t)value)<<8) & 0xFF00u) | \
+          ((((uint16_t)value)>>8) & 0x00FFu))
 
 #define TDS_BYTE_SWAP32(value)                     \
-         (((((unsigned long)value)<<24) & 0xFF000000)  | \
-          ((((unsigned long)value)<< 8) & 0x00FF0000)  | \
-          ((((unsigned long)value)>> 8) & 0x0000FF00)  | \
-          ((((unsigned long)value)>>24) & 0x000000FF))
+         (((((uint32_t)value)<<24) & 0xFF000000u)| \
+          ((((uint32_t)value)<< 8) & 0x00FF0000u)| \
+          ((((uint32_t)value)>> 8) & 0x0000FF00u)| \
+          ((((uint32_t)value)>>24) & 0x000000FFu))
 
 #define is_end_token(x) ((x) >= TDS_DONE_TOKEN && (x) <= TDS_DONEINPROC_TOKEN)
 

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -15,3 +15,12 @@ endif(WIN32)
 
 add_executable(bsqlodbc bsqlodbc.c)
 target_link_libraries(bsqlodbc tdsodbc replacements tdsutils ${libs})
+
+if(WIN32)
+INSTALL(TARGETS tsql bsqlodbc
+        PUBLIC_HEADER DESTINATION include
+		RUNTIME DESTINATION bin	
+		LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib
+        )
+endif(WIN32)

--- a/src/apps/bsqldb.c
+++ b/src/apps/bsqldb.c
@@ -190,15 +190,15 @@ main(int argc, char *argv[])
 
 	fprintf(options.verbose, "%s:%d: Verbose operation enabled\n", options.appname, __LINE__);
 	
+	/* Select the specified database, if any */
+	if (options.database)
+		DBSETLDBNAME(login, options.database);
+
 	/* 
 	 * Connect to the server 
 	 */
 	if ((dbproc = dbopen(login, options.servername)) == NULL)
 		return 1;
-	
-	/* Switch to the specified database, if any */
-	if (options.database)
-		dbuse(dbproc, options.database);
 
 	/* 
 	 * Read the queries and write the results

--- a/src/apps/datacopy.c
+++ b/src/apps/datacopy.c
@@ -345,6 +345,8 @@ login_to_databases(const BCPPARAMDATA * pdata, DBPROCESS ** dbsrc, DBPROCESS ** 
 		DBSETLUSER(slogin, pdata->src.user);
 	if (pdata->src.pass)
 		DBSETLPWD(slogin, pdata->src.pass);
+	if (pdata->src.db)
+		DBSETLDBNAME(slogin, pdata->src.db);
 	DBSETLAPP(slogin, "Migrate Data");
 
 	/* if packet size specified, set in login record */
@@ -362,17 +364,14 @@ login_to_databases(const BCPPARAMDATA * pdata, DBPROCESS ** dbsrc, DBPROCESS ** 
 		goto cleanup;
 	}
 
-	if (dbuse(*dbsrc, pdata->src.db) == FAIL) {
-		fprintf(stderr, "Can't change database to %s .\n", pdata->src.db);
-		goto cleanup;
-	}
-
 	dlogin = dblogin();
 
 	if (pdata->dest.user)
 		DBSETLUSER(dlogin, pdata->dest.user);
 	if (pdata->dest.pass)
 		DBSETLPWD(dlogin, pdata->dest.pass);
+	if (pdata->dest.db)
+		DBSETLDBNAME(dlogin, pdata->dest.db);
 	DBSETLAPP(dlogin, "Migrate Data");
 
 	/* Enable bulk copy for this connection. */
@@ -391,11 +390,6 @@ login_to_databases(const BCPPARAMDATA * pdata, DBPROCESS ** dbsrc, DBPROCESS ** 
 
 	if ((*dbdest = dbopen(dlogin, pdata->dest.server)) == (DBPROCESS *) NULL) {
 		fprintf(stderr, "Can't connect to destination server.\n");
-		goto cleanup;
-	}
-
-	if (dbuse(*dbdest, pdata->dest.db) == FAIL) {
-		fprintf(stderr, "Can't change database to %s .\n", pdata->dest.db);
 		goto cleanup;
 	}
 

--- a/src/apps/defncopy.c
+++ b/src/apps/defncopy.c
@@ -192,6 +192,10 @@ main(int argc, char *argv[])
 		}
 	}
 	
+	/* Select the specified database, if any */
+	if (options.database)
+		DBSETLDBNAME(login, options.database);
+
 	/* 
 	 * Connect to the server 
 	 */
@@ -200,10 +204,6 @@ main(int argc, char *argv[])
 		fprintf(stderr, "There was a problem connecting to the server.\n");
 		exit(1);
 	}
-
-	/* Switch to the specified database, if any */
-	if (options.database)
-		dbuse(dbproc, options.database);
 
 	/* 
 	 * Read the procedure names and move their texts.  

--- a/src/apps/fisql/fisql.c
+++ b/src/apps/fisql/fisql.c
@@ -715,6 +715,9 @@ main(int argc, char *argv[])
 	if (logintime >= 0) {
 		dbsetlogintime(logintime);
 	}
+	if (database_name) {
+		DBSETLDBNAME(login, database_name);
+	}
 	if ((dbproc = dbopen(login, server)) == NULL) {
 		fprintf(stderr, "fisql: dbopen() failed.\n");
 		reset_term();
@@ -736,9 +739,6 @@ main(int argc, char *argv[])
 	}
 	if (perfstats) {
 		dbsetopt(dbproc, DBSTAT, "time", 0);
-	}
-	if (database_name) {
-		dbuse(dbproc, database_name);
 	}
 
 	while (1) {

--- a/src/ctlib/CMakeLists.txt
+++ b/src/ctlib/CMakeLists.txt
@@ -31,3 +31,12 @@ endif()
 if(MINGW OR CYGWIN)
 	set_target_properties(ct PROPERTIES LINK_FLAGS "--static")
 endif(MINGW OR CYGWIN)
+
+if(WIN32)
+INSTALL(TARGETS ct ct-static
+        PUBLIC_HEADER DESTINATION include
+		RUNTIME DESTINATION bin	
+		LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib
+        )
+endif(WIN32)

--- a/src/ctlib/ct.c
+++ b/src/ctlib/ct.c
@@ -436,10 +436,7 @@ ct_con_props(CS_CONNECTION * con, CS_INT action, CS_INT property, CS_VOID * buff
 			break;
 		case CS_BULK_LOGIN:
 			memcpy(&intval, buffer, sizeof(intval));
-			if (intval)
-				tds_set_bulk(tds_login, 1);
-			else
-				tds_set_bulk(tds_login, 0);
+			tds_set_bulk(tds_login, !!intval);
 			break;
 		case CS_PACKETSIZE:
 			memcpy(&intval, buffer, sizeof(intval));

--- a/src/ctlib/ct.c
+++ b/src/ctlib/ct.c
@@ -925,7 +925,7 @@ ct_send(CS_COMMAND * cmd)
 				return CS_FAIL;
 			}
 			pparam_info = paraminfoalloc(tds, dyn->param_list);
-			if (!pparam_info)
+			if (!pparam_info && dyn->param_list)
 				return CS_FAIL;
 			tds_free_input_params(tdsdyn);
 			tdsdyn->params = pparam_info;

--- a/src/ctlib/unittests/.gitignore
+++ b/src/ctlib/unittests/.gitignore
@@ -31,4 +31,5 @@ datafmt
 rpc_fail
 row_count
 all_types
+long_binary
 libcommon.a

--- a/src/ctlib/unittests/CMakeLists.txt
+++ b/src/ctlib/unittests/CMakeLists.txt
@@ -9,7 +9,7 @@ foreach(target t0001 t0002 t0003 t0004
 	cs_config cancel blk_in
 	blk_out ct_cursor ct_cursors
 	ct_dynamic blk_in2 datafmt
-	all_types)
+	all_types long_binary)
 	add_executable(c_${target} EXCLUDE_FROM_ALL ${target}.c)
 	set_target_properties(c_${target} PROPERTIES OUTPUT_NAME ${target})
 	if (target STREQUAL "all_types")

--- a/src/ctlib/unittests/Makefile.am
+++ b/src/ctlib/unittests/Makefile.am
@@ -32,6 +32,7 @@ TESTS = \
 	rpc_fail$(EXEEXT) \
 	row_count$(EXEEXT) \
 	all_types$(EXEEXT) \
+	long_binary$(EXEEXT) \
 	$(NULL)
 
 check_PROGRAMS	=	$(TESTS)
@@ -69,6 +70,7 @@ rpc_fail_SOURCES	= rpc_fail.c
 row_count_SOURCES	= row_count.c
 all_types_SOURCES	= all_types.c
 all_types_LDFLAGS	= -static ../libct.la ../../tds/unittests/libcommon.a -shared
+long_binary_SOURCES	= long_binary.c
 
 noinst_LIBRARIES = libcommon.a
 libcommon_a_SOURCES = common.c common.h

--- a/src/ctlib/unittests/long_binary.c
+++ b/src/ctlib/unittests/long_binary.c
@@ -82,6 +82,7 @@ main(int argc, char **argv)
 	CS_SMALLINT ind = 0;
 	CS_DATAFMT datafmt;
 	CS_INT ret;
+	int i;
 
 	printf("-- begin --\n");
 
@@ -106,7 +107,7 @@ main(int argc, char **argv)
 
 	printf("sending %d bytes\n", buffer_len);
 
-	for (int i = 0; i < buffer_len; i++)
+	for (i = 0; i < buffer_len; i++)
 		buffer[i] = (rand() % 16);
 
 	memset(&datafmt, 0, sizeof(datafmt));

--- a/src/ctlib/unittests/long_binary.c
+++ b/src/ctlib/unittests/long_binary.c
@@ -1,0 +1,130 @@
+/* Test we can insert long binary into database.
+ */
+#include <config.h>
+
+#include <stdio.h>
+
+#if HAVE_STDLIB_H
+#include <stdlib.h>
+#endif /* HAVE_STDLIB_H */
+
+#if HAVE_STRING_H
+#include <string.h>
+#endif /* HAVE_STRING_H */
+
+#include <ctpublic.h>
+#include "common.h"
+
+static const CS_INT unused = CS_UNUSED, nullterm = CS_NULLTERM;
+static CS_INT result_len = -1;
+
+static CS_RETCODE
+csmsg_callback(CS_CONTEXT *ctx, CS_CLIENTMSG * emsgp)
+{
+	printf("message from csmsg_callback(): %s\n", emsgp->msgstring);
+	return CS_SUCCEED;
+}
+
+static void
+check_ret(const char *name, CS_RETCODE ret)
+{
+	if (ret != CS_SUCCEED) {
+		fprintf(stderr, "%s(): failed\n", name);
+		exit(1);
+	}
+}
+
+static int
+fetch_results(CS_COMMAND * command)
+{
+	CS_INT result_type, int_result, copied, rows_read;
+	CS_SMALLINT ind = 0;
+	CS_DATAFMT datafmt;
+	int result = 0;
+
+	memset(&datafmt, 0, sizeof(datafmt));
+	datafmt.datatype = CS_INT_TYPE;
+	datafmt.count = 1;
+
+	check_ret("ct_results", ct_results(command, &result_type));
+	do {
+		if (result_type == CS_ROW_RESULT) {
+			check_ret("ct_bind", ct_bind(command, 1, &datafmt, &int_result, &copied, &ind));
+			check_ret("ct_fetch", ct_fetch(command, CS_UNUSED, CS_UNUSED, CS_UNUSED, &rows_read));
+			printf("received %d bytes\n", (int) int_result);
+			result_len = int_result;
+		}
+		if (result_type == CS_CMD_FAIL) {
+			result = 1;
+		}
+	} while (ct_results(command, &result_type) == CS_SUCCEED);
+	return result;
+}
+
+static int
+execute_sql(CS_COMMAND * command, const char *sql)
+{
+	printf("executing sql: %s\n", sql);
+	check_ret("ct_command", ct_command(command, CS_LANG_CMD, sql, nullterm, unused));
+	check_ret("ct_send", ct_send(command));
+	return fetch_results(command);
+}
+
+int
+main(int argc, char **argv)
+{
+	int verbose = 0;
+	CS_COMMAND *command;
+	CS_CONNECTION *connection;
+	CS_CONTEXT *context;
+	unsigned char buffer[65536];
+	CS_INT buffer_len = 8192;
+	CS_SMALLINT ind = 0;
+	CS_DATAFMT datafmt;
+	CS_INT ret;
+
+	printf("-- begin --\n");
+
+	check_ret("try_ctlogin", try_ctlogin(&context, &connection, &command, verbose));
+	check_ret("cs_config", cs_config(context, CS_SET, CS_MESSAGE_CB, (CS_VOID *) csmsg_callback, unused, 0));
+
+	execute_sql(command, "if object_id('mps_table') is not null drop table mps_table");
+	execute_sql(command, "if object_id('mps_rpc') is not null drop procedure mps_rpc");
+	/* if this query fails probably we are using wrong database vendor or version */
+	ret = execute_sql(command, "create procedure mps_rpc (@varbinary_param varbinary(max)) as "
+		    "insert mps_table values (@varbinary_param) " "select len(varbinary_data) from mps_table");
+	if (ret != 0) {
+		try_ctlogout(context, connection, command, verbose);
+		return 0;
+	}
+	execute_sql(command, "create table mps_table (varbinary_data varbinary(max))");
+
+	if (argc > 1)
+		buffer_len = atoi(argv[1]);
+	if (buffer_len < 0 || buffer_len > sizeof(buffer))
+		return 1;
+
+	printf("sending %d bytes\n", buffer_len);
+
+	for (int i = 0; i < buffer_len; i++)
+		buffer[i] = (rand() % 16);
+
+	memset(&datafmt, 0, sizeof(datafmt));
+	strcpy(datafmt.name, "@varbinary_param");
+	datafmt.namelen = nullterm;
+	datafmt.datatype = CS_IMAGE_TYPE;
+	datafmt.status = CS_INPUTVALUE;
+
+	check_ret("ct_command", ct_command(command, CS_RPC_CMD, "mps_rpc", nullterm, unused));
+	check_ret("ct_setparam", ct_setparam(command, &datafmt, buffer, &buffer_len, &ind));
+	check_ret("ct_send", ct_send(command));
+
+	fetch_results(command);
+
+	execute_sql(command, "drop table mps_table");
+	execute_sql(command, "drop procedure mps_rpc");
+	try_ctlogout(context, connection, command, verbose);
+
+	printf("-- end --\n");
+	return (result_len == buffer_len) ? 0 : 1;
+}

--- a/src/ctlib/unittests/rpc_fail.c
+++ b/src/ctlib/unittests/rpc_fail.c
@@ -4,7 +4,7 @@
 
 #if HAVE_STDLIB_H
 #include <stdlib.h>
-#endif /* HAVE_STRING_H */
+#endif /* HAVE_STDLIB_H */
 
 #if HAVE_STRING_H
 #include <string.h>

--- a/src/dblib/CMakeLists.txt
+++ b/src/dblib/CMakeLists.txt
@@ -24,3 +24,12 @@ endif()
 if(MINGW OR CYGWIN)
 	set_target_properties(sybdb PROPERTIES LINK_FLAGS "--static")
 endif(MINGW OR CYGWIN)
+
+if(WIN32)
+INSTALL(TARGETS sybdb db-lib
+        PUBLIC_HEADER DESTINATION include
+		RUNTIME DESTINATION bin	
+		LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib
+        )
+endif(WIN32)

--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -1434,9 +1434,6 @@ dbuse(DBPROCESS * dbproc, const char *name)
 	CHECK_CONN(FAIL);
 	CHECK_NULP(name, "dbuse", 2, FAIL);
 
-	if (!dbproc->tds_socket)
-		return FAIL;
-
 	/* quote name */
 	query = tds_new(char, tds_quote_id(dbproc->tds_socket, NULL, name, -1) + 6);
 	if (!query) {

--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -911,7 +911,7 @@ dbsetlbool(LOGINREC * login, int value, int which)
 
 	switch (which) {
 	case DBSETBCP:
-		tds_set_bulk(login->tds_login, (TDS_TINYINT) value);
+		tds_set_bulk(login->tds_login, !!value);
 		return SUCCEED;
 		break;
 	case DBSETUTF16:
@@ -6218,14 +6218,12 @@ dbmorecmds(DBPROCESS * dbproc)
 		return FAIL;
 	}
 
-	if (dbproc->tds_socket->res_info->more_results == 0) {
-		tdsdump_log(TDS_DBG_FUNC, "more_results == 0; returns FAIL\n");
+	if (!dbproc->tds_socket->res_info->more_results) {
+		tdsdump_log(TDS_DBG_FUNC, "more_results is false; returns FAIL\n");
 		return FAIL;
 	}
 	
-	assert(dbproc->tds_socket->res_info->more_results == 1);
-	
-	tdsdump_log(TDS_DBG_FUNC, "more_results == 1; returns SUCCEED\n");
+	tdsdump_log(TDS_DBG_FUNC, "more_results is true; returns SUCCEED\n");
 	
 	return SUCCEED;
 }

--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -3856,7 +3856,7 @@ dbsprline(DBPROCESS * dbproc, char *buffer, DBINT buf_len, DBCHAR line_char)
  * \param buffer output buffer
  * \param buf_len size of \a buffer
  * \retval SUCCEED \a buffer filled.
- * \retval FAIL insufficient spaace in \a buffer, usually.
+ * \retval FAIL insufficient space in \a buffer, usually.
  * \sa dbprhead(), dbprrow(), dbsetopt(), dbspr1row(), dbspr1rowlen(), dbsprline().
  */
 RETCODE

--- a/src/odbc/CMakeLists.txt
+++ b/src/odbc/CMakeLists.txt
@@ -43,3 +43,12 @@ add_library(tdsodbc_static STATIC
 if (NOT WIN32)
 	set_target_properties(tdsodbc_static PROPERTIES COMPILE_FLAGS -fPIC)
 endif()
+
+if(WIN32)
+INSTALL(TARGETS tdsodbc tdsodbc_static
+        PUBLIC_HEADER DESTINATION include
+		RUNTIME DESTINATION bin	
+		LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib
+        )
+endif(WIN32)

--- a/src/odbc/CMakeLists.txt
+++ b/src/odbc/CMakeLists.txt
@@ -45,7 +45,7 @@ if (NOT WIN32)
 endif()
 
 if(WIN32)
-INSTALL(TARGETS tdsodbc tdsodbc_static
+INSTALL(TARGETS tdsodbc
         PUBLIC_HEADER DESTINATION include
 		RUNTIME DESTINATION bin	
 		LIBRARY DESTINATION lib

--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -380,7 +380,7 @@ odbc_connect(TDS_DBC * dbc, TDSLOGIN * login)
 	if (dbc->attr.mars_enabled != SQL_MARS_ENABLED_NO)
 		login->mars = 1;
 	if (dbc->attr.bulk_enabled != SQL_BCP_OFF)
-		tds_set_bulk(login, 1);
+		tds_set_bulk(login, true);
 
 #ifdef ENABLE_ODBC_WIDE
 	/* force utf-8 in order to support wide characters */

--- a/src/pool/CMakeLists.txt
+++ b/src/pool/CMakeLists.txt
@@ -2,3 +2,12 @@ set(libs ${lib_NETWORK} ${lib_BASE})
 
 add_executable(tdspool main.c config.c member.c user.c util.c)
 target_link_libraries(tdspool tdssrv tds replacements tdsutils ${libs})
+
+if(WIN32)
+INSTALL(TARGETS tdspool
+        PUBLIC_HEADER DESTINATION include
+		RUNTIME DESTINATION bin	
+		LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib
+        )
+endif(WIN32)

--- a/src/replacements/CMakeLists.txt
+++ b/src/replacements/CMakeLists.txt
@@ -36,3 +36,13 @@ if (NOT WIN32)
 endif()
 
 add_subdirectory(unittests)
+
+
+if(WIN32)
+INSTALL(TARGETS replacements
+        PUBLIC_HEADER DESTINATION include
+		RUNTIME DESTINATION bin	
+		LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib
+        )
+endif(WIN32)

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -6,3 +6,12 @@ add_library(tdssrv STATIC
 if (NOT WIN32)
 	set_target_properties(tdssrv PROPERTIES COMPILE_FLAGS -fPIC)
 endif()
+
+if(WIN32)
+INSTALL(TARGETS tdssrv
+        PUBLIC_HEADER DESTINATION include
+		RUNTIME DESTINATION bin	
+		LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib
+        )
+endif(WIN32)

--- a/src/tds/CMakeLists.txt
+++ b/src/tds/CMakeLists.txt
@@ -47,3 +47,12 @@ add_library(tds STATIC
 if (NOT WIN32)
 	set_target_properties(tds PROPERTIES COMPILE_FLAGS -fPIC)
 endif()
+
+if(WIN32)
+INSTALL(TARGETS tds
+        PUBLIC_HEADER DESTINATION include
+		RUNTIME DESTINATION bin	
+		LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib
+        )
+endif(WIN32)

--- a/src/tds/CMakeLists.txt
+++ b/src/tds/CMakeLists.txt
@@ -47,12 +47,3 @@ add_library(tds STATIC
 if (NOT WIN32)
 	set_target_properties(tds PROPERTIES COMPILE_FLAGS -fPIC)
 endif()
-
-if(WIN32)
-INSTALL(TARGETS tds
-        PUBLIC_HEADER DESTINATION include
-		RUNTIME DESTINATION bin	
-		LIBRARY DESTINATION lib
-		ARCHIVE DESTINATION lib
-        )
-endif(WIN32)

--- a/src/tds/Makefile.am
+++ b/src/tds/Makefile.am
@@ -1,29 +1,52 @@
-
+NULL=
 SUBDIRS			=	. unittests
 AM_CPPFLAGS		=	-I$(top_srcdir)/include
 
 noinst_LTLIBRARIES	=	libtds.la
+libtds_la_SOURCES = \
+	mem.c \
+	token.c \
+	util.c \
+	login.c \
+	read.c \
+	write.c \
+	convert.c \
+	numeric.c \
+	config.c \
+	query.c \
+	iconv.c \
+	locale.c \
+	vstrbuild.c \
+	getmac.c \
+	data.c \
+	net.c \
+	tls.c \
+	tds_checks.c \
+	log.c \
+	bulk.c \
+	packet.c \
+	stream.c \
+	random.c \
+	sec_negotiate.c \
+	sec_negotiate_gnutls.h \
+	sec_negotiate_openssl.h \
+	$(NULL)
 if HAVE_SSPI
-AUTH_FILES_DIST	= challenge.c gssapi.c
-AUTH_FILES	= sspi.c
+libtds_la_SOURCES += sspi.c
 else
-AUTH_FILES	= challenge.c gssapi.c
-AUTH_FILES_DIST	= sspi.c
+libtds_la_SOURCES += challenge.c gssapi.c
 endif
-libtds_la_SOURCES=	mem.c token.c util.c login.c read.c \
-	write.c convert.c numeric.c config.c query.c iconv.c \
-	locale.c vstrbuild.c \
-	getmac.c data.c net.c tls.c \
-	tds_checks.c log.c \
-	bulk.c packet.c stream.c random.c \
-	sec_negotiate_gnutls.h sec_negotiate_openssl.h sec_negotiate.c \
-	$(AUTH_FILES)
-libtds_la_LDFLAGS=
+libtds_la_LDFLAGS =
 libtds_la_LIBADD = $(NETWORK_LIBS)
 
-noinst_HEADERS		= tds_willconvert.h encodings.h num_limits.h tds_types.h
-EXTRA_DIST		= tds_willconvert.h encodings.h num_limits.h tds_types.h \
-	CMakeLists.txt $(AUTH_FILES_DIST)
+GENERATED_HEADER_FILES = tds_willconvert.h encodings.h num_limits.h tds_types.h
+noinst_HEADERS = $(GENERATED_HEADER_FILES)
+EXTRA_DIST = $(GENERATED_HEADER_FILES) \
+	CMakeLists.txt \
+	challenge.c \
+	gssapi.c \
+	sspi.c \
+	$(NULL)
 
 # Perl is needed to build from a repository checkout.
 # Perl is *not* needed to build from a tarball.  
@@ -34,7 +57,7 @@ EXTRA_DIST		= tds_willconvert.h encodings.h num_limits.h tds_types.h \
 data.c:	tds_types.h
 
 if HAVE_PERL_SOURCES
-BUILT_SOURCES = tds_willconvert.h encodings.h num_limits.h tds_types.h
+BUILT_SOURCES = $(GENERATED_HEADER_FILES)
 
 clean-local: 
 	cd $(srcdir) && rm -f $(BUILT_SOURCES)

--- a/src/tds/bulk.c
+++ b/src/tds/bulk.c
@@ -823,7 +823,7 @@ tds_bcp_start(TDSSOCKET *tds, TDSBCPINFO *bcpinfo)
 		return rc;
 
 	/* set we want to switch to bulk state */
-	tds->bulk_query = 1;
+	tds->bulk_query = true;
 
 	/*
 	 * In TDS 5 we get the column information as a result set from the "insert bulk" command.
@@ -1102,7 +1102,7 @@ tds_writetext_start(TDSSOCKET *tds, const char *objname, const char *textptr, co
 		return rc;
 
 	/* set we want to switch to bulk state */
-	tds->bulk_query = 1;
+	tds->bulk_query = true;
 
 	/* read the end token */
 	rc = tds_process_simple_query(tds);

--- a/src/tds/login.c
+++ b/src/tds/login.c
@@ -84,7 +84,7 @@ tds_set_passwd(TDSLOGIN * tds_login, const char *password)
 	return true;
 }
 void
-tds_set_bulk(TDSLOGIN * tds_login, TDS_TINYINT enabled)
+tds_set_bulk(TDSLOGIN * tds_login, bool enabled)
 {
 	tds_login->bulk_copy = enabled ? 1 : 0;
 }

--- a/src/tds/mem.c
+++ b/src/tds/mem.c
@@ -477,6 +477,7 @@ tds_set_current_results(TDSSOCKET *tds, TDSRESULTINFO *info)
 		tds->current_results->attached_to = NULL;
 	if (info)
 		info->attached_to = tds;
+	tds->in_row = (info != NULL);
 	tds->current_results = info;
 }
 
@@ -488,6 +489,7 @@ tds_detach_results(TDSRESULTINFO *info)
 {
 	if (info && info->attached_to) {
 		info->attached_to->current_results = NULL;
+		info->attached_to->in_row = false;
 		info->attached_to = NULL;
 	}
 }
@@ -660,6 +662,7 @@ tds_free_all_results(TDSSOCKET * tds)
 	tds->param_info = NULL;
 	tds_free_compute_results(tds);
 	tds->has_status = false;
+	tds->in_row = false;
 	tds->ret_status = 0;
 	if (tds->cur_dyn)
 		tds_detach_results(tds->cur_dyn->res_info);

--- a/src/tds/mem.c
+++ b/src/tds/mem.c
@@ -659,7 +659,7 @@ tds_free_all_results(TDSSOCKET * tds)
 	tds_free_param_results(tds->param_info);
 	tds->param_info = NULL;
 	tds_free_compute_results(tds);
-	tds->has_status = 0;
+	tds->has_status = false;
 	tds->ret_status = 0;
 	if (tds->cur_dyn)
 		tds_detach_results(tds->cur_dyn->res_info);

--- a/src/tds/net.c
+++ b/src/tds/net.c
@@ -81,6 +81,12 @@
 #include <sys/eventfd.h>
 #endif /* HAVE_SYS_EVENTFD_H */
 
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <mstcpip.h>
+#endif
+
 #include <freetds/tds.h>
 #include <freetds/string.h>
 #include <freetds/tls.h>
@@ -246,6 +252,14 @@ tds_setup_socket(TDS_SYS_SOCKET *p_sock, struct addrinfo *addr, unsigned int por
 	char ipaddr[128];
 	int retval, len, err;
 	char *errstr;
+#if defined(_WIN32)
+	struct tcp_keepalive keepalive = {
+		TRUE,
+		TDS_SOCKET_KEEPALIVE_IDLE * 1000,
+		TDS_SOCKET_KEEPALIVE_INTERVAL * 1000
+	};
+	DWORD written;
+#endif
 
 	*p_oserr = 0;
 
@@ -265,7 +279,14 @@ tds_setup_socket(TDS_SYS_SOCKET *p_sock, struct addrinfo *addr, unsigned int por
 	setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, (const void *) &len, sizeof(len));
 #endif
 
-#if defined(TCP_KEEPIDLE) && defined(TCP_KEEPINTVL)
+#if defined(_WIN32)
+	if (WSAIoctl(sock, SIO_KEEPALIVE_VALS, &keepalive, sizeof(keepalive),
+		     NULL, 0, &written, NULL, NULL) != 0) {
+		errstr = sock_strerror(*p_oserr = sock_errno);
+		tdsdump_log(TDS_DBG_ERROR, "error setting keepalive: %s\n", errstr);
+		sock_strerror_free(errstr);
+	}
+#elif defined(TCP_KEEPIDLE) && defined(TCP_KEEPINTVL)
 	len = TDS_SOCKET_KEEPALIVE_IDLE;
 	setsockopt(sock, SOL_TCP, TCP_KEEPIDLE, (const void *) &len, sizeof(len));
 	len = TDS_SOCKET_KEEPALIVE_INTERVAL;

--- a/src/tds/net.c
+++ b/src/tds/net.c
@@ -238,6 +238,10 @@ tds_get_socket_error(TDS_SYS_SOCKET sock)
 static TDSERRNO
 tds_setup_socket(TDS_SYS_SOCKET *p_sock, struct addrinfo *addr, unsigned int port, int *p_oserr)
 {
+	enum {
+		TDS_SOCKET_KEEPALIVE_IDLE = 40,
+		TDS_SOCKET_KEEPALIVE_INTERVAL = 2
+	};
 	TDS_SYS_SOCKET sock;
 	char ipaddr[128];
 	int retval, len, err;
@@ -262,9 +266,9 @@ tds_setup_socket(TDS_SYS_SOCKET *p_sock, struct addrinfo *addr, unsigned int por
 #endif
 
 #if defined(TCP_KEEPIDLE) && defined(TCP_KEEPINTVL)
-	len = 40;
+	len = TDS_SOCKET_KEEPALIVE_IDLE;
 	setsockopt(sock, SOL_TCP, TCP_KEEPIDLE, (const void *) &len, sizeof(len));
-	len = 2;
+	len = TDS_SOCKET_KEEPALIVE_INTERVAL;
 	setsockopt(sock, SOL_TCP, TCP_KEEPINTVL, (const void *) &len, sizeof(len));
 #endif
 

--- a/src/tds/query.c
+++ b/src/tds/query.c
@@ -1851,7 +1851,7 @@ tds_deferred_unprepare(TDSCONNECTION * conn, TDSDYNAMIC * dyn)
 		return TDS_SUCCESS;
 	}
 
-	dyn->defer_close = 1;
+	dyn->defer_close = true;
 	conn->pending_close = 1;
 
 	return TDS_SUCCESS;
@@ -3118,7 +3118,7 @@ tds_deferred_cursor_dealloc(TDSCONNECTION *conn, TDSCURSOR * cursor)
 	if (!tds_cursor_check_allocated(conn, cursor))
 		return TDS_SUCCESS;
 
-	cursor->defer_close = 1;
+	cursor->defer_close = true;
 	conn->pending_close = 1;
 
 	return TDS_SUCCESS;

--- a/src/tds/token.c
+++ b/src/tds/token.c
@@ -157,7 +157,7 @@ tds_process_default_tokens(TDSSOCKET * tds, int marker)
 		marker = tds_peek(tds);
 		if (marker != TDS_PARAM_TOKEN && marker != TDS_DONEPROC_TOKEN && marker != TDS_DONE_TOKEN)
 			break;
-		tds->has_status = 1;
+		tds->has_status = true;
 		tds->ret_status = ret_status;
 		tdsdump_log(TDS_DBG_INFO1, "tds_process_default_tokens: return status is %d\n", tds->ret_status);
 		break;
@@ -679,7 +679,7 @@ tds_process_tokens(TDSSOCKET *tds, TDS_INT *result_type, int *done_flags, unsign
 				/* TODO optimize */
 				flag &= ~TDS_STOPAT_PROC;
 				SET_RETURN(TDS_STATUS_RESULT, PROC);
-				tds->has_status = 1;
+				tds->has_status = true;
 				tds->ret_status = ret_status;
 				tdsdump_log(TDS_DBG_FUNC, "tds_process_tokens: return status is %d\n", tds->ret_status);
 				rc = TDS_SUCCESS;
@@ -2110,7 +2110,7 @@ tds_process_end(TDSSOCKET * tds, int marker, int *flags_parm)
 		if (tds->bulk_query) {
 			tds->out_flag = TDS_BULK;
 			tds_set_state(tds, TDS_SENDING);
-			tds->bulk_query = 0;
+			tds->bulk_query = false;
 		} else {
 			tds_set_state(tds, TDS_IDLE);
 			if (tds->conn->pending_close)

--- a/src/tds/token.c
+++ b/src/tds/token.c
@@ -2089,6 +2089,8 @@ tds_process_end(TDSSOCKET * tds, int marker, int *flags_parm)
 		    "\t\terror = %d\n"
 		    "\t\tdone_count_valid = %d\n", more_results, was_cancelled, error, done_count_valid);
 
+	tds->in_row = false;
+
 	if (tds->res_info) {
 		tds->res_info->more_results = more_results;
 		/* FIXME this should not happen !!! */
@@ -2290,6 +2292,9 @@ tds_process_info(TDSSOCKET * tds, int marker)
 	TDSMESSAGE msg;
 
 	CHECK_TDS_EXTRA(tds);
+
+	if (!tds->in_row)
+		tds_free_all_results(tds);
 
 	/* make sure message has been freed */
 	memset(&msg, 0, sizeof(TDSMESSAGE));

--- a/src/tds/token.c
+++ b/src/tds/token.c
@@ -2371,7 +2371,7 @@ tds_process_info(TDSSOCKET * tds, int marker)
 	msg.line_number = IS_TDS72_PLUS(tds->conn) ? tds_get_int(tds) : tds_get_smallint(tds);
 
 	/*
-	 * If the server doesen't provide an sqlstate, map one via server native errors
+	 * If the server doesn't provide an sqlstate, map one via server native errors
 	 * I'm assuming there is not a protocol I'm missing to fetch these from the server?
 	 * I know sybase has an sqlstate column in it's sysmessages table, mssql doesn't and
 	 * TDS_EED_TOKEN is not being called for me.

--- a/src/tds/token.c
+++ b/src/tds/token.c
@@ -649,7 +649,7 @@ tds_process_tokens(TDSSOCKET *tds, TDS_INT *result_type, int *done_flags, unsign
 			}
 			/* I don't know when this it's false but it happened, also server can send garbage... */
 			if (tds->current_results)
-				tds->current_results->rows_exist = 1;
+				tds->current_results->rows_exist = true;
 			SET_RETURN(TDS_ROW_RESULT, ROW);
 
 			switch (marker) {
@@ -664,7 +664,7 @@ tds_process_tokens(TDSSOCKET *tds, TDS_INT *result_type, int *done_flags, unsign
 		case TDS_CMP_ROW_TOKEN:
 			/* I don't know when this it's false but it happened, also server can send garbage... */
 			if (tds->res_info)
-				tds->res_info->rows_exist = 1;
+				tds->res_info->rows_exist = true;
 			SET_RETURN(TDS_COMPUTE_RESULT, COMPUTE);
 			rc = tds_process_compute(tds);
 			break;
@@ -2026,7 +2026,7 @@ tds_process_pending_closes(TDSSOCKET *tds)
 			    || TDS_FAILED(tds_process_simple_query(tds))) {
 				all_closed = 0;
 			} else {
-				cursor->defer_close = 0;
+				cursor->defer_close = false;
 				tds_cursor_dealloc(tds, cursor);
 			}
 		}
@@ -2047,7 +2047,7 @@ tds_process_pending_closes(TDSSOCKET *tds)
 			    || TDS_FAILED(tds_process_simple_query(tds))) {
 				all_closed = 0;
 			} else {
-				dyn->defer_close = 0;
+				dyn->defer_close = false;
 			}
 		}
 		tds_release_dynamic(&dyn);
@@ -2068,7 +2068,7 @@ tds_process_pending_closes(TDSSOCKET *tds)
 static TDSRET
 tds_process_end(TDSSOCKET * tds, int marker, int *flags_parm)
 {
-	int more_results, was_cancelled, error, done_count_valid;
+	bool more_results, was_cancelled, error, done_count_valid;
 	int tmp;
 	TDS_INT8 rows_affected;
 

--- a/src/tds/unittests/Makefile.am
+++ b/src/tds/unittests/Makefile.am
@@ -53,7 +53,7 @@ iconv_fread_SOURCES	= iconv_fread.c
 charconv_SOURCES	= charconv.c
 toodynamic_SOURCES	= toodynamic.c
 nulls_SOURCES	= nulls.c
-readconf_SOURCES	= readconf.c
+readconf_SOURCES	= readconf.c readconf.in
 corrupt_SOURCES	=	corrupt.c
 declarations_SOURCES	=	declarations.c
 
@@ -69,5 +69,5 @@ AM_LDFLAGS	=	-no-install -L../.libs -R $(abs_builddir)/../.libs
 endif
 LIBS		=	../libtds.la ../../replacements/libreplacements.la $(LTLIBICONV) $(NETWORK_LIBS)
 CLEANFILES	=	tdsdump.out
-EXTRA_DIST	=	CMakeLists.txt readconf.in
+EXTRA_DIST	=	CMakeLists.txt
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -20,11 +20,3 @@ if (NOT WIN32)
 	set_target_properties(tdsutils PROPERTIES COMPILE_FLAGS -fPIC)
 endif()
 
-if(WIN32)
-INSTALL(TARGETS tdsutils
-        PUBLIC_HEADER DESTINATION include
-		RUNTIME DESTINATION bin	
-		LIBRARY DESTINATION lib
-		ARCHIVE DESTINATION lib
-        )
-endif(WIN32)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -19,3 +19,12 @@ add_library(tdsutils STATIC
 if (NOT WIN32)
 	set_target_properties(tdsutils PROPERTIES COMPILE_FLAGS -fPIC)
 endif()
+
+if(WIN32)
+INSTALL(TARGETS tdsutils
+        PUBLIC_HEADER DESTINATION include
+		RUNTIME DESTINATION bin	
+		LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib
+        )
+endif(WIN32)


### PR DESCRIPTION
When someone is compiling freetds in windows and use CMake, he can't install the developer files in an install folder.
This pull request adds necesary install target to CMakeLists.txt to install *.h, *.lib, *.exe and *.dll in next directory structure:
/install_folder
/install_folder/include/*.h
/install_folder/include/freetds/version.h
/install_folder/lib/*.lib
/install_folder/bin/*.exe *.dll

This pull install all targets defined in CMakelists.txt, but I'm not sure if all *.lib must be exported.
Neither, I'm not sure if all headers files must be exported or not. 
