### PR TITLE
dblib: fix rpc blob data output

### DIFF
--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -4735,7 +4735,8 @@ dbretdata(DBPROCESS * dbproc, int retnum)
 		return NULL;
 
 	column = param_info->columns[retnum - 1];
-	/* FIXME blob are stored is different way */
+	if (is_blob_col(column))
+		return (BYTE *) ((TDSBLOB *) column->column_data)->textvalue;
 	return (BYTE *) column->column_data;
 }
 

--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -4722,7 +4722,9 @@ dbretname(DBPROCESS * dbproc, int retnum)
 BYTE *
 dbretdata(DBPROCESS * dbproc, int retnum)
 {
-	TDSCOLUMN *column;
+	TDSCOLUMN *colinfo;
+	BYTE *res;
+	const static BYTE empty[1] = { 0 };
 	TDSPARAMINFO *param_info;
 
 	tdsdump_log(TDS_DBG_FUNC, "dbretdata(%p, %d)\n", dbproc, retnum);
@@ -4734,10 +4736,17 @@ dbretdata(DBPROCESS * dbproc, int retnum)
 	if (!param_info || !param_info->columns || retnum < 1 || retnum > param_info->num_cols)
 		return NULL;
 
-	column = param_info->columns[retnum - 1];
-	if (is_blob_col(column))
-		return (BYTE *) ((TDSBLOB *) column->column_data)->textvalue;
-	return (BYTE *) column->column_data;
+	colinfo = param_info->columns[retnum - 1];
+
+	if (colinfo->column_cur_size < 0)
+		return NULL;
+
+	res = colinfo->column_data;
+	if (is_blob_col(colinfo))
+		res = (BYTE *) ((TDSBLOB *) res)->textvalue;
+	if (!res)
+		return (BYTE *) empty;
+	return res;
 }
 
 /**


### PR DESCRIPTION
The dblib API to get data from an RPC output parameter, `dbretdata` doesn't handle BLOB types, while the same works for result sets with `dbdata`.
As both functions seem to handle the same kind of data (from `tds_put_data`), here a proposed fix that brings `dbretdata` up to date.
There's 3 commits in this branch: the first one is a minimal patch, then a cleaner one copies all logic and finally a common internal function is added to avoid duplication.

This works in my limited testing and it seems unlikely the current code (a pointer to column_data) is relied upon, thanks for looking into this !