### PR TITLE
Fix blob(4) size for converted text

### DIFF
--- a/src/dblib/unittests/.gitignore
+++ b/src/dblib/unittests/.gitignore
@@ -28,6 +28,7 @@ t0016.err
 t0017.err
 t0017.out
 rpc
+rpc70
 dbmorecmds
 bcp
 thread

--- a/src/dblib/unittests/CMakeLists.txt
+++ b/src/dblib/unittests/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(d_common STATIC common.c common.h)
 
 foreach(target t0001 t0002 t0003 t0004 t0005 t0006 t0007 t0008 t0009
 	t0011 t0012 t0013 t0014 t0015 t0016 t0017 t0018 t0019 t0020
-	t0021 t0022 t0023 rpc dbmorecmds bcp thread text_buffer
+	t0021 t0022 t0023 rpc rpc70 dbmorecmds bcp thread text_buffer
 	done_handling timeout hang null null2 setnull numeric pending
 	cancel spid canquery batch_stmt_ins_sel batch_stmt_ins_upd bcp_getl)
 	add_executable(d_${target} EXCLUDE_FROM_ALL ${target}.c)

--- a/src/dblib/unittests/Makefile.am
+++ b/src/dblib/unittests/Makefile.am
@@ -22,6 +22,7 @@ TESTS =	\
 	t0022$(EXEEXT) \
 	t0023$(EXEEXT) \
 	rpc$(EXEEXT) \
+	rpc70$(EXEEXT) \
 	dbmorecmds$(EXEEXT) \
 	bcp$(EXEEXT) \
 	thread$(EXEEXT) \
@@ -72,6 +73,7 @@ t0021_SOURCES	=	t0021.c
 t0022_SOURCES	=	t0022.c t0022.sql
 t0023_SOURCES	=	t0023.c t0023.sql
 rpc_SOURCES	=	rpc.c rpc.sql
+rpc70_SOURCES	=	rpc70.c rpc70.sql
 dbmorecmds_SOURCES =	dbmorecmds.c dbmorecmds.sql
 bcp_SOURCES	=	bcp.c bcp.h bcp.sql
 thread_SOURCES	=	thread.c bcp.h

--- a/src/dblib/unittests/rpc70.c
+++ b/src/dblib/unittests/rpc70.c
@@ -1,0 +1,205 @@
+/*
+ * Purpose: Test RPC NTEXT input with TDS 7.0
+ * Functions:  dbretdata dbretlen dbrettype dbrpcinit dbrpcparam dbrpcsend
+ */
+
+#include "common.h"
+
+static RETCODE init_proc(DBPROCESS * dbproc, const char *name);
+int ignore_err_handler(DBPROCESS * dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr);
+int ignore_msg_handler(DBPROCESS * dbproc, DBINT msgno, int state, int severity, char *text, char *server, char *proc, int line);
+
+static RETCODE
+init_proc(DBPROCESS * dbproc, const char *name)
+{
+	RETCODE ret = FAIL;
+
+	if (name[0] != '#') {
+		printf("Dropping procedure %s\n", name);
+		sql_cmd(dbproc);
+		dbsqlexec(dbproc);
+		while (dbresults(dbproc) != NO_MORE_RESULTS) {
+			/* nop */
+		}
+	}
+
+	printf("Creating procedure %s\n", name);
+	sql_cmd(dbproc);
+	if ((ret = dbsqlexec(dbproc)) == FAIL) {
+		if (name[0] == '#')
+			printf("Failed to create procedure %s. Wrong permission or not MSSQL.\n", name);
+		else
+			printf("Failed to create procedure %s. Wrong permission.\n", name);
+	}
+	while (dbresults(dbproc) != NO_MORE_RESULTS) {
+		/* nop */
+	}
+	return ret;
+}
+
+static int failed = 0;
+
+int
+ignore_msg_handler(DBPROCESS * dbproc, DBINT msgno, int state, int severity, char *text, char *server, char *proc, int line)
+{
+	int ret;
+
+	dbsetuserdata(dbproc, (BYTE*) &msgno);
+	/* printf("(ignoring message %d)\n", msgno); */
+	ret = syb_msg_handler(dbproc, msgno, state, severity, text, server, proc, line);
+	dbsetuserdata(dbproc, NULL);
+	return ret;
+}
+/*
+ * The bad procedure name message has severity 15, causing db-lib to call the error handler after calling the message handler.
+ * This wrapper anticipates that behavior, and again sets the userdata, telling the handler this error is expected. 
+ */
+int
+ignore_err_handler(DBPROCESS * dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr)
+{	
+	int erc;
+	static int recursion_depth = 0;
+	
+	if (dbproc == NULL) {	
+		printf("expected error %d: \"%s\"\n", dberr, dberrstr? dberrstr : "");
+		return INT_CANCEL;
+	}
+	
+	if (recursion_depth++) {
+		printf("error %d: \"%s\"\n", dberr, dberrstr? dberrstr : "");
+		printf("logic error: recursive call to ignore_err_handler\n");
+		exit(1);
+	}
+	dbsetuserdata(dbproc, (BYTE*) &dberr);
+	/* printf("(ignoring error %d)\n", dberr); */
+	erc = syb_err_handler(dbproc, severity, dberr, oserr, dberrstr, oserrstr);
+	dbsetuserdata(dbproc, NULL);
+	recursion_depth--;
+	return erc;
+}
+
+
+struct parameters_t {
+	const char   *name;
+	BYTE         status;
+	int          type;
+	DBINT        maxlen;
+	DBINT        datalen;
+	BYTE         *value;
+};
+
+#define PARAM_STR(s) sizeof(s)-1, (BYTE*) s
+static struct parameters_t bindings[] = {
+	  { "", 0, SYBNTEXT,  -1,  PARAM_STR("test123") }
+	, { "", DBRPCRETURN, SYBVARCHAR,  7, 0, NULL }
+	, { NULL, 0, 0, 0, 0, NULL }
+};
+
+static void
+bind_param(DBPROCESS *dbproc, struct parameters_t *pb)
+{
+	RETCODE erc;
+	const char *name = pb->name[0] ? pb->name : NULL;
+
+	if ((erc = dbrpcparam(dbproc, name, pb->status, pb->type, pb->maxlen, pb->datalen, pb->value)) == FAIL) {
+		fprintf(stderr, "Failed line %d: dbrpcparam\n", __LINE__);
+		failed++;
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	LOGINREC *login;
+	DBPROCESS *dbproc;
+
+	char teststr[8000+1];
+	int i;
+	int rettype = 0, retlen = 0;
+	char proc[] = "#rpc70";
+	char *proc_name = proc;
+
+	struct parameters_t *pb;
+
+	RETCODE erc;
+
+	set_malloc_options();
+
+	read_login_info(argc, argv);
+
+	printf("Starting %s\n", argv[0]);
+
+	dbinit();
+
+	dberrhandle(syb_err_handler);
+	dbmsghandle(syb_msg_handler);
+
+	printf("About to logon\n");
+
+	login = dblogin();
+	DBSETLPWD(login, PASSWORD);
+	DBSETLUSER(login, USER);
+	DBSETLAPP(login, "rpc70");
+	/* force TDS 7.0 login */
+	DBSETLVERSION(login, DBVERSION_70);
+
+	printf("About to open %s.%s\n", SERVER, DATABASE);
+
+	dbproc = dbopen(login, SERVER);
+	if (strlen(DATABASE))
+		dbuse(dbproc, DATABASE);
+	dbloginfree(login);
+
+	if (dbtds(dbproc) != DBTDS_7_0) {
+		fprintf(stderr, "Failed line %d: version is not 7.0\n", __LINE__);
+		failed = 1;
+	}
+
+	dberrhandle(ignore_err_handler);
+	dbmsghandle(ignore_msg_handler);
+
+	printf("trying to create a temporary stored procedure\n");
+	if (FAIL == init_proc(dbproc, proc_name)) {
+		printf("trying to create a permanent stored procedure\n");
+		if (FAIL == init_proc(dbproc, ++proc_name))
+			exit(EXIT_FAILURE);
+	}
+
+	dberrhandle(syb_err_handler);
+	dbmsghandle(syb_msg_handler);
+
+	printf("Created procedure %s\n", proc_name);
+
+	erc = dbrpcinit(dbproc, proc_name, 0);	/* no options */
+	if (erc == FAIL) {
+		fprintf(stderr, "Failed line %d: dbrpcinit\n", __LINE__);
+		failed = 1;
+	}
+	for (pb = bindings; pb->name != NULL; pb++)
+		bind_param(dbproc, pb);
+	erc = dbrpcsend(dbproc);
+	if (erc == FAIL) {
+		fprintf(stderr, "Failed line %d: dbrpcsend\n", __LINE__);
+		exit(1);
+	}
+	while (dbresults(dbproc) != NO_MORE_RESULTS)
+		continue;
+	if (dbnumrets(dbproc) != 1) {	/* dbnumrets missed something */
+		fprintf(stderr, "Expected 1 output parameters.\n");
+		exit(1);
+	}
+	i = 1;
+	rettype = dbrettype(dbproc, i);
+	retlen = dbretlen(dbproc, i);
+	dbconvert(dbproc, rettype, dbretdata(dbproc, i), retlen, SYBVARCHAR, (BYTE*) teststr, -1);
+	if (strcmp(teststr, "test123") != 0) {
+		fprintf(stderr, "Unexpected '%s' results.\n", teststr);
+		exit(1);
+	}
+
+	dbexit();
+
+	printf("%s %s\n", __FILE__, (failed ? "failed!" : "OK"));
+
+	return failed ? 1 : 0;
+}

--- a/src/dblib/unittests/rpc70.sql
+++ b/src/dblib/unittests/rpc70.sql
@@ -1,0 +1,20 @@
+CREATE PROCEDURE #rpc70
+  @a char(10)
+, @b char(10) OUTPUT
+AS
+SET @b=@a
+RETURN 0
+
+go
+IF OBJECT_ID('rpc70') IS NOT NULL DROP PROC rpc70
+go
+CREATE PROCEDURE rpc70
+  @a char(10)
+, @b char(10) OUTPUT
+AS
+SET @b=@a
+RETURN 0
+
+go
+IF OBJECT_ID('rpc70') IS NOT NULL DROP PROC rpc70
+go

--- a/src/tds/data.c
+++ b/src/tds/data.c
@@ -1056,7 +1056,8 @@ tds_generic_put(TDSSOCKET * tds, TDSCOLUMN * curcol, int bcp7)
 			tds_put_int(tds, colsize);
 			break;
 		case 4:	/* It's a BLOB... */
-			colsize = MIN(colsize, size);
+			if (!converted)
+				colsize = MIN(colsize, size);
 			/* mssql require only size */
 			if (bcp7 && is_blob_type(curcol->on_server.column_type)) {
 				static const unsigned char textptr[] = {


### PR DESCRIPTION
In my tests, data sent as NTEXT using TDS 7.0 (varint 4) appears to be truncated in half, due to an incorrect size set in tds_generic_put.
This patch ensures the actual column size it set to the converted data length.