### PR TITLE
add nossl build on appveyor

### DIFF
--- a/misc/appveyor.yml
+++ b/misc/appveyor.yml
@@ -96,6 +96,13 @@ build_script:
   - set PATH=%PATH%;c:\openssl-win%WIDTH%
   - src\apps\tsql.exe -C
   - cd ..
+  - mkdir build_withoutssl
+  - cd build_withoutssl
+  - set OPENSSL_ROOT_DIR=
+  - "%WITH_COMPILER% cmake -G \"NMake Makefiles\" -DCMAKE_BUILD_TYPE=Release -DWITH_OPENSSL=off \"-DCMAKE_INSTALL_PREFIX:PATH=%DEST_DIR%\" .."
+  - "%WITH_COMPILER% nmake"
+  - src\apps\tsql.exe -C
+  - cd ..
 
 test_script:
   - set INSTANCENAME=SQL2014
@@ -133,6 +140,17 @@ after_test:
   - "%WITH_COMPILER% nmake install"
   - set DESTDIR=vs%VS_VERSION%_%WIDTH%-%APPVEYOR_REPO_BRANCH%
   - 7z a ..\%DESTDIR%.zip %DESTDIR%
+  # END of non-test code specifically related to creation of artifacts published via GitHub  - 7z a ..\%DESTDIR%.zip %DESTDIR%
+  - cd ..
+  # Create zipball artifact for nossl
+  - cd build_withoutssl
+  - set DESTDIR=C:/
+  - echo %DESTDIR%
+  - "%WITH_COMPILER% nmake install"
+  - set DESTDIR=vs%VS_VERSION%_%WIDTH%-%APPVEYOR_REPO_BRANCH%
+  - echo %DESTDIR%
+  - 7z a ..\%DESTDIR%_withoutssl.zip %DESTDIR%
+  # END of non-test code specifically related to creation of artifacts published via GitHub  - 7z a ..\%DESTDIR%.zip %DESTDIR%
   - cd ..
 
 artifacts:


### PR DESCRIPTION
generate a separate package without ssl support, to allow pymssql windows packages to be build statically linked without ssl, its in a separate package to simplify the installation and to keep packages small