### PR TITLE
dblib: fix TDS_DONE_RESULT empty rowsets:

### DIFF
--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -1760,8 +1760,10 @@ _dbresults(DBPROCESS * dbproc)
 					dbproc->dbresults_state = _DB_RES_NEXT_RESULT;
 					if (done_flags & TDS_DONE_ERROR)
 						return FAIL;
-					if (result_type == TDS_DONE_RESULT)
+					if (result_type == TDS_DONE_RESULT) {
+						tds_free_all_results(tds);
 						return SUCCEED;
+					}
 					break;
 
 				case _DB_RES_RESULTSET_EMPTY:

--- a/src/dblib/unittests/.gitignore
+++ b/src/dblib/unittests/.gitignore
@@ -47,3 +47,4 @@ batch_stmt_ins_sel
 batch_stmt_ins_upd
 libcommon.a
 bcp_getl
+empty_rowsets

--- a/src/dblib/unittests/CMakeLists.txt
+++ b/src/dblib/unittests/CMakeLists.txt
@@ -4,7 +4,8 @@ foreach(target t0001 t0002 t0003 t0004 t0005 t0006 t0007 t0008 t0009
 	t0011 t0012 t0013 t0014 t0015 t0016 t0017 t0018 t0019 t0020
 	t0021 t0022 t0023 rpc dbmorecmds bcp thread text_buffer
 	done_handling timeout hang null null2 setnull numeric pending
-	cancel spid canquery batch_stmt_ins_sel batch_stmt_ins_upd bcp_getl)
+	cancel spid canquery batch_stmt_ins_sel batch_stmt_ins_upd bcp_getl
+	empty_rowsets)
 	add_executable(d_${target} EXCLUDE_FROM_ALL ${target}.c)
 	set_target_properties(d_${target} PROPERTIES OUTPUT_NAME ${target})
 	target_link_libraries(d_${target} d_common sybdb replacements tdsutils ${lib_NETWORK} ${lib_BASE})

--- a/src/dblib/unittests/Makefile.am
+++ b/src/dblib/unittests/Makefile.am
@@ -39,7 +39,8 @@ TESTS =	\
 	canquery$(EXEEXT) \
 	batch_stmt_ins_sel$(EXEEXT) \
 	batch_stmt_ins_upd$(EXEEXT) \
-	bcp_getl$(EXEEXT)
+	bcp_getl$(EXEEXT) \
+	empty_rowsets$(EXEEXT)
 
 check_PROGRAMS	=	$(TESTS)
 
@@ -90,6 +91,7 @@ canquery_SOURCES=	canquery.c canquery.sql
 batch_stmt_ins_sel_SOURCES	=	batch_stmt_ins_sel.c batch_stmt_ins_sel.sql
 batch_stmt_ins_upd_SOURCES	=	batch_stmt_ins_upd.c batch_stmt_ins_upd.sql
 bcp_getl_SOURCES=	bcp_getl.c
+empty_rowsets_SOURCES = empty_rowsets.c empty_rowsets.sql
 
 noinst_LIBRARIES = libcommon.a
 libcommon_a_SOURCES = common.c common.h

--- a/src/dblib/unittests/empty_rowsets.c
+++ b/src/dblib/unittests/empty_rowsets.c
@@ -1,0 +1,69 @@
+/*
+ * Purpose: Test handling of empty rowsets
+ * Functions: dbcmd dbdata dbdatlen dbnextrow dbresults dbsqlexec
+ */
+
+#include "common.h"
+
+static int failed = 0;
+static void set_failed(int line)
+{
+	failed = 1;
+	fprintf(stderr, "Failed check at line %d\n", line);
+}
+#define set_failed() set_failed(__LINE__)
+
+int
+main(int argc, char *argv[])
+{
+	LOGINREC *login;
+	DBPROCESS *dbproc;
+	int ret_code;
+	int num_cols;
+	int num_res;
+
+	set_malloc_options();
+
+	read_login_info(argc, argv);
+	fprintf(stdout, "Starting %s\n", argv[0]);
+	dbinit();
+
+	dberrhandle(syb_err_handler);
+	dbmsghandle(syb_msg_handler);
+
+	fprintf(stdout, "About to logon\n");
+
+	login = dblogin();
+	DBSETLPWD(login, PASSWORD);
+	DBSETLUSER(login, USER);
+	DBSETLAPP(login, "t0012");
+
+	dbproc = dbopen(login, SERVER);
+	if (strlen(DATABASE)) {
+		dbuse(dbproc, DATABASE);
+	}
+	dbloginfree(login);
+	fprintf(stdout, "After logon\n");
+
+	/* select */
+	sql_cmd(dbproc);
+	dbsqlexec(dbproc);
+
+	num_res = 0;
+	while ((ret_code = dbresults(dbproc)) == SUCCEED) {
+		num_cols = dbnumcols(dbproc);
+		fprintf(stdout, "Result %d has %d columns\n", num_res, num_cols);
+		if (!(num_res % 2) && num_cols)
+			set_failed();
+		while(dbnextrow(dbproc) != NO_MORE_ROWS) {};
+		num_res++;
+	}
+	if (ret_code == FAIL)
+		set_failed();
+
+	dbclose(dbproc);
+	dbexit();
+
+	fprintf(stdout, "%s %s\n", __FILE__, (failed ? "failed!" : "OK"));
+	return failed ? 1 : 0;
+}

--- a/src/dblib/unittests/empty_rowsets.sql
+++ b/src/dblib/unittests/empty_rowsets.sql
@@ -1,0 +1,5 @@
+set arithabort on
+select 1
+set arithabort on
+select 2
+go


### PR DESCRIPTION
Fix #175 

Change introduced by 34e1f69 can produce an incorrect resultset.
This patch resets the internal result structure in this case.