### PR TITLE
Memory leak in tls.c

### DIFF
--- a/src/tds/tls.c
+++ b/src/tds/tls.c
@@ -1035,6 +1035,7 @@ tds_ssl_init(TDSSOCKET *tds)
 		tls_msg = "checking hostname";
 		if (!cert || !check_hostname(cert, tds_dstr_cstr(&tds->login->server_host_name)))
 			goto cleanup;
+		X509_free(cert);
 	}
 
 	tdsdump_log(TDS_DBG_INFO1, "handshake succeeded!!\n");


### PR DESCRIPTION
OpenSSL documentation for[ SSL_get_peer_certificate](https://www.openssl.org/docs/manmaster/man3/SSL_get_peer_certificate.html) states:

> The reference count of the X509 object is incremented by one, so that it will not be destroyed when the session containing the peer certificate is freed.

Meaning that, when the certificate hostname is checked, OpenSSL keeps a reference to that certificate each time, so each connection that's made will leak more and more memory.

Since the cert is not used after the hostname check, I've added a X509_free() call that will free the certificate.
