### PR TITLE
Using system root CAs when establishing a connection.

### DIFF
--- a/src/tds/tls.c
+++ b/src/tds/tls.c
@@ -1035,6 +1035,7 @@ tds_ssl_init(TDSSOCKET *tds)
 		tls_msg = "checking hostname";
 		if (!cert || !check_hostname(cert, tds_dstr_cstr(&tds->login->server_host_name)))
 			goto cleanup;
+		X509_free(cert);
 	}
 
 	tdsdump_log(TDS_DBG_INFO1, "handshake succeeded!!\n");

--- a/src/tds/tls.c
+++ b/src/tds/tls.c
@@ -584,12 +584,12 @@ int tds_update_cert_store_with_root_cas(SSL_CTX *ctx)
 	X509 *x509 = NULL;
 #ifdef WIN32
 	HCERTSTORE hStore = NULL;
-    PCCERT_CONTEXT pContext = NULL;
+	PCCERT_CONTEXT pContext = NULL;
 #else
-    FILE *f = NULL;
-    const char *path = NULL;
-	char *fullPath = NULL;
-    DIR *dirp = NULL;
+	FILE *f = NULL;
+	const char *path = NULL;
+		char *fullPath = NULL;
+	DIR *dirp = NULL;
 	struct dirent entry;
 	struct dirent *endp;
 	struct stat st;
@@ -599,8 +599,8 @@ int tds_update_cert_store_with_root_cas(SSL_CTX *ctx)
 
 #ifdef WIN32
 	hStore = CertOpenSystemStore(NULL, "ROOT");
-    if (!hStore)
-        goto err;
+	if (!hStore)
+		goto err;
 
 	while (pContext = CertEnumCertificatesInStore(hStore, pContext))
 	{
@@ -608,69 +608,69 @@ int tds_update_cert_store_with_root_cas(SSL_CTX *ctx)
 		{
 #else
 
-    path = getenv(X509_get_default_cert_dir_env());
-    if (!path)
-        path = X509_get_default_cert_dir();
+			path = getenv(X509_get_default_cert_dir_env());
+			if (!path)
+				path = X509_get_default_cert_dir();
 
-    if (!path)
-        goto err;
+			if (!path)
+				goto err;
 
-    if (stat(path, &st) == -1)
-        goto err;
+			if (stat(path, &st) == -1)
+				goto err;
 
-    if((dirp = opendir(path)) == NULL)
-        goto err;
+			if((dirp = opendir(path)) == NULL)
+				goto err;
 
-    for (;;) {
-        endp = NULL;
+			for (;;) {
+				endp = NULL;
 
-        // Attempt to read the next entry in the directory
-        if (readdir_r(dirp, &entry, &endp) == -1)
-            goto err;
+			// Attempt to read the next entry in the directory
+			if (readdir_r(dirp, &entry, &endp) == -1)
+				goto err;
 
-        // If the read fail, break out of the loop because we're done
-        if (endp == NULL)
-            break;
+			// If the read fail, break out of the loop because we're done
+			if (endp == NULL)
+				break;
 
-        // Verify that the file ends in ".pem" already, because we're only interested in
-        // existing PEM files. Furthermore, this also filters out the "." and ".." files
-        if (strlen(entry.d_name) <= strlen(".pem") ||
-                strcmp(entry.d_name + strlen(entry.d_name) - strlen(".pem"), ".pem") != 0)
-            continue;
+			// Verify that the file ends in ".pem" already, because we're only interested in
+			// existing PEM files. Furthermore, this also filters out the "." and ".." files
+			if (strlen(entry.d_name) <= strlen(".pem") ||
+				strcmp(entry.d_name + strlen(entry.d_name) - strlen(".pem"), ".pem") != 0)
+				continue;
 
-        // If the path is now invalid, we're done
-        if (stat(path, &st) == -1)
-            goto err;
+			// If the path is now invalid, we're done
+			if (stat(path, &st) == -1)
+				goto err;
 
-        // We don't want to process directories
-        if (S_ISDIR(st.st_mode) == 0)
-            continue;
+			// We don't want to process directories
+			if (S_ISDIR(st.st_mode) == 0)
+				continue;
 
-        // Build the full path to the file for us to open
-        fullPath = (char*)malloc(strlen(path) + 1 + strlen(entry.d_name) + 1);
-        strcpy(fullPath, path);
-        strcat(fullPath, "/");
-        strcat(fullPath, entry.d_name);
+			// Build the full path to the file for us to open
+			fullPath = (char*)malloc(strlen(path) + 1 + strlen(entry.d_name) + 1);
+			strcpy(fullPath, path);
+			strcat(fullPath, "/");
+			strcat(fullPath, entry.d_name);
 
-        f = fopen(fullPath, "rb");
+			f = fopen(fullPath, "rb");
 
-        if (!f)
-            goto err;
+			if (!f)
+				goto err;
 
-		x509 = PEM_read_X509(f, NULL, NULL, NULL);
-		if (x509 == NULL)
-			goto err;
+			x509 = PEM_read_X509(f, NULL, NULL, NULL);
+			if (x509 == NULL)
+				goto err;
 
-		if(f)
-		{
-            fclose(f);
-            f = NULL;
-		}
-		if (fullPath)
-		{
-			free(fullPath);
-			fullPath = NULL;
-		}
+			if(f)
+			{
+				fclose(f);
+				f = NULL;
+			}
+			if (fullPath)
+			{
+				free(fullPath);
+				fullPath = NULL;
+			}
 #endif
 
 			X509_STORE_add_cert(store, x509);
@@ -687,8 +687,8 @@ err:
 #ifdef WIN32
 	if (hStore) CertCloseStore(hStore, 0);
 #else
-    if (dirp) closedir(dirp);
-    if (fullPath) free(fullPath);
+	if (dirp) closedir(dirp);
+	if (fullPath) free(fullPath);
 	if (f) fclose(f);
 #endif
 

--- a/src/tds/tls.c
+++ b/src/tds/tls.c
@@ -588,7 +588,7 @@ int tds_update_cert_store_with_root_cas(SSL_CTX *ctx)
 #else
 	FILE *f = NULL;
 	const char *path = NULL;
-		char *fullPath = NULL;
+	char *fullPath = NULL;
 	DIR *dirp = NULL;
 	struct dirent entry;
 	struct dirent *endp;

--- a/src/tds/tls.c
+++ b/src/tds/tls.c
@@ -576,6 +576,111 @@ tds_ssl_deinit(TDSCONNECTION *conn)
 }
 
 #else
+
+int tds_update_cert_store_with_root_cas(SSL_CTX *ctx)
+{
+	int ret = 0;
+	X509_STORE *store = NULL;
+	X509 *x509 = NULL;
+#ifdef WIN32
+	HCERTSTORE hStore = NULL;
+    PCCERT_CONTEXT pContext = NULL;
+#else
+	FILE *f = NULL;
+    DIR *dirp = NULL;
+    char path[] = "/etc/ssl/certs/";
+	char *fullPath = NULL;
+	struct dirent entry;
+	struct dirent *endp;
+	struct stat st;
+#endif
+	
+	store = SSL_CTX_get_cert_store(ctx);
+
+#ifdef WIN32
+	hStore = CertOpenSystemStore(NULL, "ROOT");
+    if (!hStore)
+        goto err;
+
+	while (pContext = CertEnumCertificatesInStore(hStore, pContext))
+	{
+		if ((x509 = d2i_X509(NULL, (const unsigned char **)&pContext->pbCertEncoded, pContext->cbCertEncoded)) != NULL)
+		{
+#else
+
+    if (stat(path, &st) == -1)
+        goto err;
+
+    if((dirp = opendir(path)) == NULL)
+        goto err;
+
+    for (;;) {
+        endp = NULL;
+
+        // Attempt to read the next entry in the directory
+        if (readdir_r(dirp, &entry, &endp) == -1)
+            goto err;
+
+        // If the read fail, break out of the loop because we're done
+        if (endp == NULL)
+            break;
+
+        // Verify that the file ends in ".pem" already, because we're only interested in
+        // existing PEM files. Furthermore, this also filters out the "." and ".." files
+        if (strlen(entry.d_name) <= strlen(".pem") ||
+                strcmp(entry.d_name + strlen(entry.d_name) - strlen(".pem"), ".pem") != 0)
+            continue;
+
+        // If the path is now invalid, we're done
+        if (stat(path, &st) == -1)
+            goto err;
+
+        // We don't want to process directories
+        if (S_ISDIR(st.st_mode) == 0)
+            continue;
+
+        // Build the full path to the file for us to open
+        fullPath = (char*)malloc(strlen(path) + strlen(entry.d_name) + 1);
+        strcpy(fullPath, path);
+        strcat(fullPath, entry.d_name);
+
+		x509 = PEM_read_X509(f, NULL, NULL, NULL);
+		if (x509 == NULL)
+		    goto err;
+		
+		if(f)
+		{
+		    fclose(f);
+		    f = NULL;
+		}
+		if (fullPath)
+		{
+			free(fullPath);
+			fullPath = NULL;
+		}
+#endif
+		
+			X509_STORE_add_cert(store, x509);
+			X509_free(x509);
+#ifdef WIN32
+		}
+#endif
+	}
+
+	ret = 1;
+err:
+
+#ifdef WIN32
+	if (hStore) CertCloseStore(hStore, 0);
+#else
+    if (dirp) closedir(dirp);
+    if (fullPath) free(fullPath);
+	if (f) fclose(f);
+#endif
+
+	return ret;
+}
+
 static long
 tds_ssl_ctrl_login(BIO *b, int cmd, long num, void *ptr)
 {
@@ -957,7 +1062,7 @@ tds_ssl_init(TDSSOCKET *tds)
 	if (!tds_dstr_isempty(&tds->login->cafile)) {
 		tls_msg = "loading CA file";
 		if (strcasecmp(tds_dstr_cstr(&tds->login->cafile), "system") == 0)
-			ret = SSL_CTX_set_default_verify_paths(ctx);
+			ret = tds_update_cert_store_with_root_cas(ctx);
 		else
 			ret = SSL_CTX_load_verify_locations(ctx, tds_dstr_cstr(&tds->login->cafile), NULL);
 		if (ret != 1)


### PR DESCRIPTION
The issue with the method that existed already (the call to [SSL_CTX_set_default_verify_paths](https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_set_default_verify_paths.html)) is that it will:

> SSL_CTX_set_default_verify_paths() specifies that the default locations from which CA certificates are loaded should be used. There is one default directory and one default file. The default CA certificates directory is called "certs" in the default OpenSSL directory. Alternatively the SSL_CERT_DIR environment variable can be defined to override this location. The default CA certificates file is called "cert.pem" in the default OpenSSL directory. Alternatively the SSL_CERT_FILE environment variable can be defined to override this location.

So, from my understanding, it sets it to a default directory and a default file of certs.pem. Which would work fine if /etc/ssl/certs (default directory on my installation) contained a single consolidated certs.pem file, but it does not. It instead contains many .pem files, one for each root CA.

Furthermore, when using FreeTDS on Windows, there is no directory of root certificates, instead all of the certificates are managed via the Microsoft Management Console through the Certificates store. As far as I'm aware, OpenSSL does not know of this system wide certificate store (it's the same store that Chrome and other browsers use to get their trusted root certificates).

Finally, you should be able to see this lack of knowledge by FreeTDS/OpenSSL on either Linux or Windows by setting `encryption=require` and `ca file=system` in the freetds config for the server. This will force OpenSSL to establish a secure connection and attempt to use the system CA files. However, the connection should fail (at least it has failed in my build) because it does not successfully load the root CAs, and thus does not successfully verify the connection.

The change that I've proposed adds an additional function of `tds_update_cert_store_with_root_cas` to tls.c that will do two different things when called:

1. On Windows, it will make a call to open the [CertOpenSystemStore](https://msdn.microsoft.com/es-es/library/windows/desktop/aa376560(v=vs.85).aspx), when open, it will loop through all root certificates in the store and add them to the OpenSSL context's root store, providing a chain of trust for OpenSSL to verify with.
2. On Linux, it will get the default directory for OpenSSL to read certificates from via a call to X509_get_default_cert_dir_env or X509_get_default_cert_dir, it will then loop through every .pem file in that directory, read them in as X509 certs, and add them to the OpenSSL context.

The result is that, on both Windows and Linux, when using OpenSSL, the certificate chain will be able to be verified when `encryption=require` and `ca file=system` are both set.

