### PR TITLE
optimize the padding blanks, fixed the hotspot

### DIFF
--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -7500,7 +7500,7 @@ copy_data_to_host_var(DBPROCESS * dbproc, TDS_SERVER_TYPE srctype, const BYTE * 
 					if (srclen < destlen) {
 						memset(dest + srclen, ' ', destlen - srclen - 1);
 					}
-					dest[i] = '\0';
+					dest[destlen - 1] = '\0';
 					break;
 				case CHARBIND:   /* pad with blanks, NO NUL term */
 					if (limited_dest_space) {
@@ -7659,7 +7659,7 @@ copy_data_to_host_var(DBPROCESS * dbproc, TDS_SERVER_TYPE srctype, const BYTE * 
 				if (len < destlen) {
 					memset(dest + len, ' ', destlen - len - 1);
 				}
-				dest[i] = '\0';
+				dest[destlen - 1] = '\0';
 				break;
 			case CHARBIND:   /* pad with blanks, NO null term */
 				if (limited_dest_space) {

--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -7497,8 +7497,9 @@ copy_data_to_host_var(DBPROCESS * dbproc, TDS_SERVER_TYPE srctype, const BYTE * 
 						destlen = srclen; 
 					}
 					memcpy(dest, src, srclen);
-					for (i = srclen; i < destlen - 1; i++)
-						dest[i] = ' ';
+					if (srclen < destlen) {
+						memset(dest + srclen, ' ', destlen - srclen - 1);
+					}
 					dest[i] = '\0';
 					break;
 				case CHARBIND:   /* pad with blanks, NO NUL term */
@@ -7512,8 +7513,9 @@ copy_data_to_host_var(DBPROCESS * dbproc, TDS_SERVER_TYPE srctype, const BYTE * 
 						destlen = srclen; 
 					}
 					memcpy(dest, src, srclen);
-					for (i = srclen; i < destlen; i++)
-						dest[i] = ' ';
+					if (srclen < destlen) {
+						memset(dest + srclen, ' ', destlen - srclen);
+					}
 					break;
 				case VARYCHARBIND: /* strip trailing blanks, NO NUL term */
 					if (limited_dest_space) {
@@ -7654,8 +7656,9 @@ copy_data_to_host_var(DBPROCESS * dbproc, TDS_SERVER_TYPE srctype, const BYTE * 
 					destlen = len; 
 				}
 				memcpy(dest, dres.c, len);
-				for (i = len; i < destlen - 1; i++)
-					dest[i] = ' ';
+				if (len < destlen) {
+					memset(dest + len, ' ', destlen - len - 1);
+				}
 				dest[i] = '\0';
 				break;
 			case CHARBIND:   /* pad with blanks, NO null term */
@@ -7669,8 +7672,9 @@ copy_data_to_host_var(DBPROCESS * dbproc, TDS_SERVER_TYPE srctype, const BYTE * 
 					destlen = len; 
 				}
 				memcpy(dest, dres.c, len);
-				for (i = len; i < destlen; i++)
-					dest[i] = ' ';
+				if (len < destlen) {
+					memset(dest + len, ' ', destlen - len);
+				}
 				break;
 			case VARYCHARBIND: /* strip trailing blanks, NO null term */
 				if (limited_dest_space) {


### PR DESCRIPTION
[In a case following:
The destlen is too big such like 10Mb, but the srclen/len is just a few bytes, will loop almost 10 * 1024 * 1024 times to pad the blank. And then this will be a man-made hotspot.

My story...
In my rencently project, our team use freetds as a client to connect SQL Server on linux platform. We have a VARCHAR(MAX) type column in database, this column was used to store string, the length is range from 0 bytes to 10MB, mostly data were a few bytes.The function dbcollen() return 2GB when the type is VARCHAR(MAX), we just roughly truncated to 10Mb. When we got a short length data which was VARCHAR(MAX) and call the dbbind with a specified bind size(10MB), desttype(STRINGBIND).This will loop too much.
The following is Intel VTune Amplifier result.
![freetds_host_var0](https://user-images.githubusercontent.com/8721633/37774971-99f56900-2e1c-11e8-9ff4-2763f283c969.jpg)

![freetds_host_var1](https://user-images.githubusercontent.com/8721633/37774795-2688082e-2e1c-11e8-94bd-eb85dd7c6dc3.jpg)

![freetds_host_var2](https://user-images.githubusercontent.com/8721633/37774919-728b31b0-2e1c-11e8-9d70-613e8099a051.jpg)

