### PR TITLE
Fix build failure with LibreSSL 2.7

### DIFF
--- a/src/tds/sec_negotiate_openssl.h
+++ b/src/tds/sec_negotiate_openssl.h
@@ -37,6 +37,11 @@
 #error HAVE_OPENSSL not defines, this file should not be included
 #endif
 
+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL
+#undef OPENSSL_VERSION_NUMBER
+#define OPENSSL_VERSION_NUMBER 0x1000107fL
+#endif
+
 static inline const BIGNUM*
 rsa_get_n(const RSA *rsa)
 {

--- a/src/tds/tls.c
+++ b/src/tds/tls.c
@@ -75,6 +75,15 @@
 #define SSL_PTR ptr
 #else
 
+#ifdef LIBRESSL_VERSION_NUMBER
+#if LIBRESSL_VERSION_NUMBER < 0x2070000FL
+static pthread_mutex_t *openssllocks;
+#undef OPENSSL_VERSION_NUMBER
+#define OPENSSL_VERSION_NUMBER 0x1000107fL
+#endif
+#define TLS_ST_OK SSL_ST_OK
+#endif
+
 /* some compatibility layer */
 #if !HAVE_BIO_GET_DATA
 static inline void


### PR DESCRIPTION
LibreSSL 2.7 added OpenSSL 1.1 API leading to build failures

See also: https://bugs.freebsd.org/226911
Signed-off-by: Bernard Spil <brnrd@FreeBSD.org>