### PR TITLE
allow use direct connection (without conf file)

### DIFF
--- a/src/tds/config.c
+++ b/src/tds/config.c
@@ -700,6 +700,9 @@ tds_config_login(TDSLOGIN * connection, TDSLOGIN * login)
 		if (1 || tds_dstr_isempty(&connection->server_name)) 
 			res = tds_dstr_dup(&connection->server_name, &login->server_name);
 	}
+	if (res &&  !tds_dstr_isempty(&login->instance_name) && tds_dstr_isempty(&connection->instance_name)) {
+			res = tds_dstr_dup(&connection->instance_name, &login->instance_name);
+	}
 	if (login->tds_version)
 		connection->tds_version = login->tds_version;
 	if (res && !tds_dstr_isempty(&login->language)) {


### PR DESCRIPTION
Its very usefull to connect db without conf file.
example:
sprintf(conn_string, "%s", option_set->servername);
if (option_set->application_name)tds_dstr_copy(&login->tds_login->server_name, option_set->servername);
if (option_set->port >0 && option_set->port < 65536)login->tds_login->port = option_set->port;
if (option_set->instance_name)tds_dstr_copy(&login->tds_login->instance_name, option_set->instance_name);
if (option_set->application_name)tds_dstr_copy(&login->tds_login->app_name, option_set->application_name);
dbopen(login, conn_string);