### PR TITLE
make: look for userguide_desc.sgml in build dir

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -119,7 +119,6 @@ $(DOCDIR)/userguide/index.htm: 	$(DOCDIR) userguide.sgml userguide_desc.sgml \
 # try jade ...
 	test -r $(abs_srcdir)/userguide.sgml
 	test -r userguide.sgml || ln -s $(srcdir)/userguide.sgml userguide.sgml
-	test -r $(abs_srcdir)/userguide_desc.sgml
 	test -r userguide_desc.sgml || ln -s $(srcdir)/userguide_desc.sgml userguide_desc.sgml
 	(cd $(DOCDIR)/userguide && \
 	if test -n "${DOCBOOK_DSL}" ; then \


### PR DESCRIPTION
Building out-of-tree did not work because of missing the userguide_desc.sgml file in the source directory.

userguide_desc.sgml is generated to the build dir.
Previously make looked for userguide_desc.sgml in the source/doc directory, which was not a problem, when we are building in tree.
However, if we build out of tree it will not find the file.

Reproduction steps:
 1. cd to source root dir
 2. `env NOCONFIGURE=1 ./autogen.sh ; mkdir build ; cd build ; ../configure && make && echo Success`

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>