### PR TITLE
make: Add subdirs of src to DIST_SUBDIRS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,12 +9,17 @@ endif
 
 if INCPOOL
 SUBDIRS += server pool
-else !INCPOOL
+else
+DIST_SUBDIRS += server pool
 if INCSERVER
 SUBDIRS += server
+else
+DIST_SUBDIRS += server
 endif
 endif
 
 if INCAPPS
 SUBDIRS += apps
+else
+DIST_SUBDIRS += apps
 endif


### PR DESCRIPTION
Subdirectories of `src/` should get into the tarball when we `make dist`, no matter the configuration before.

I ran into this problem, when I configured with `--disable-pool --disable-server` options, and created a `make dist` tarball. When I untar'd the tarball, I tried to configure and build with the same flags, but it threw an error during configure:
`config.status: error: cannot find input file: 'src/server/Makefile.in'`

Reproduction command:
`env NOCONFIGURE=1 ./autogen.sh ; ./configure --disable-pool --disable-server && make dist ; tar xzvf freetds*.tar.gz && cd freetds* ; ./configure --disable-pool --disable-server && make && echo Success`

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>