### PR TITLE
tds.h: include socket.h

### DIFF
--- a/include/freetds/tds.h
+++ b/include/freetds/tds.h
@@ -44,6 +44,10 @@
 #include <arpa/inet.h>
 #endif /* HAVE_ARPA_INET_H */
 
+#if HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif /* HAVE_SYS_SOCKET_H */
+
 /* forward declaration */
 typedef struct tdsiconvinfo TDSICONV;
 typedef struct tds_connection TDSCONNECTION;


### PR DESCRIPTION
On AIX the `sys/socket.h` file is needed directly for values like `AF_INET` or `AF_INET6`.
There were 2 files which used these values, but did not include `socket.h`, and both of them had `tds.h` included, so I decided to put the include there.

The files are:
src/replacements/getaddrinfo.c
src/replacements/socketpair.c

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>