### PR TITLE
Fix bulk insert multibyte string support in column/table name

### DIFF
--- a/src/tds/bulk.c
+++ b/src/tds/bulk.c
@@ -736,7 +736,10 @@ tds7_bcp_send_colmetadata(TDSSOCKET *tds, TDSBCPINFO *bcpinfo)
 		TDSSTATICINSTREAM r;
 		TDSSTATICOUTSTREAM w;
 		/* table and column names are sysname(nvarchar(128)) which is max 128*2 bytes */
-		char sysname_buf[128*2];
+		/* table name can be in form of database_name.schema_name.table_name */
+		/* also database_name, schema_name, table_name can contain [] or "" as quotes and escaping of ]] or "" */
+		/* so we get (128 * 2 * 2 + 2) * 3 + 2 maximum */
+		char sysname_buf[(128 * 2 * 2 + 2) * 3 + 2];
 		int res;
 
 		bcpcol = bcpinfo->bindinfo->columns[i];


### PR DESCRIPTION
When column name (or table name in blob type case) has non ASCII characters, length of such string was calculated incorrectly.
In such cases bulk insert fails with:
```
Msg 4804, Level 17, State 1
        While reading current row from host, a premature end-of-message was encountered--an incoming data stream was interrupted when the server expected to see more data. The host program may have terminated. Ensure that you are using a supported client application programming interface (API).
```

To reproduce:
1. Use `client charset = UTF8` (with other charsets you might encounter other error (buffer overflow while converting column name - this error is not addressed hire)).
2. Create table with column that contains at least 1 character which is > 1 byte in UTF-8.
For example:
    * `¯\_(ツ)_/¯`. Current len 13, correct 9.
    * `ж`. Single Cyrillic letter. Current len 2, correct 1.
    * `Yдд`. One ASCII + 2 Cyrillic letters. Current len 5, correct 3.
3. `BULK INSERT` at least 1 row of any correct value in that column => ERROR.

MSSQL expects `UTF-16 length / 2` (actual length in letters), current implementation gives `client charset length`.