### PR TITLE
Fix for accessing "SQL Database managed instance" on Azure

### DIFF
--- a/src/tds/config.c
+++ b/src/tds/config.c
@@ -701,7 +701,8 @@ tds_config_login(TDSLOGIN * connection, TDSLOGIN * login)
 	DSTR *res = &login->server_name;
 
 	if (!tds_dstr_isempty(&login->server_name)) {
-		if (1 || tds_dstr_isempty(&connection->server_name)) 
+        // overwrite server_name only if not yet set or set to default
+		if (tds_dstr_isempty(&connection->server_name) || strcmp(tds_dstr_cstr(&connection->server_name), TDS_DEF_SERVER) == 0)
 			res = tds_dstr_dup(&connection->server_name, &login->server_name);
 	}
 	if (login->tds_version)


### PR DESCRIPTION
Dear Freddy,

recently I started evaluating an "Azure managed SQL Server (most recent: 12.0.2000.8)" which did not work from python (pymssql). I quickly learned, I'll have to manualy compile FreeTDS with OpenSSL. This worked, and I was able to connect with TSQL, but not via pymssql. I started debugging (TDSDUMPCONFIG) and found the only difference:

- tsql: server_name=host
- pymssql: server_name=host:1433

Googling around brought up "https://github.com/pymssql/pymssql/issues/330" to workarund the "Cannot open server "1433D"" problem. So it is suggested to use "**user@host**" instead of only "user". This workaround is even mentioned on "http://pymssql.org/en/stable/azure.html" and in Azure Docs as well.

**But this workaround did not work.** 

So I started analysing the sourcecode of pymssql, which looked okay to me (it passes "host:port") to FreeTDS. I analysed then FreeTDS and found "_config.c_" which does a lot with the server_name (e.g. stripping away the port and setting the port in the connection struct - _parse_server_name_for_port_). Further down (where my change is) it undoes all these changes and resets server_name to the data of the login. "1 || " Looks as well as someone put this in for debugging reasions...

I had to add the check for "TDS_DEF_SERVER" to not break the behaviour from TSQL. An alternative approach would be a strstr for ':'.

I hope that my fix is extremely helpful for all people that use pymssql and maybe even PHP with Azure SQL. 

With this fix applied:
- TSQL works (tested succesfully: onpremise MSSQL, Azure SQL managed)
- pymssql works (tested succesfully: onpremise MSSQL, Azure SQL managed)
- the username will be applied **without** @host (simply "user")

Warm regards from Munich

Thorsten





