### PR TITLE
fixes for tds_listen in server/login.c

### DIFF
--- a/src/server/login.c
+++ b/src/server/login.c
@@ -75,15 +75,15 @@ TDSSOCKET *
 tds_listen(TDSCONTEXT * ctx, int ip_port)
 {
 	TDSSOCKET *tds;
-	struct sockaddr_in sin;
+	struct sockaddr_in6 sin;
 	TDS_SYS_SOCKET fd, s;
 	socklen_t len;
 
-	sin.sin_addr.s_addr = INADDR_ANY;
-	sin.sin_port = htons((short) ip_port);
-	sin.sin_family = AF_INET;
+	sin.sin6_addr = in6addr_any;
+	sin.sin6_port = htons((short) ip_port);
+	sin.sin6_family = AF_INET6;
 
-	s = socket(AF_INET, SOCK_STREAM, 0);
+	s = socket(AF_INET6, SOCK_STREAM, 0);
 	if (TDS_IS_SOCKET_INVALID(s)) {
 		perror("socket");
 		return NULL;

--- a/src/server/login.c
+++ b/src/server/login.c
@@ -108,6 +108,7 @@ tds_listen(TDSCONTEXT * ctx, int ip_port)
 	/* TODO proper charset */
 	tds_iconv_open(tds->conn, "ISO8859-1", 0);
 	/* get_incoming(tds->s); */
+	tds->state = TDS_IDLE;
 	return tds;
 }
 


### PR DESCRIPTION
Here's some fixes for tds_listen in server/login.c.

The first changes AF_INET to AF_INET6, allowing it to accept connexions via IPv6. It'll still work with IPv4.

The second updates the state to TDS_IDLE when a client connects. Without this, it'll remain as TDS_DEAD, meaning that the call to tds_alloc_read_login in server/unittest.c will always fail.