### PR TITLE
Change severity for "DBPROCESS is dead or not enabled": EXINFO -> EXCOMM

### DIFF
--- a/doc/dblib_errors.txt
+++ b/doc/dblib_errors.txt
@@ -196,7 +196,7 @@ SYBECRSUPDTAB	EXPROGRAM	Update or insert operations using bind variables require
 SYBECSYN	EXCONVERSION	Attempt to convert data stopped by syntax error in source field.
 SYBECUFL	EXCONVERSION	Data conversion resulted in underflow.
 SYBEDBPS	EXRESOURCE	Maximum number of DBPROCESSes already allocated.
-SYBEDDNE	EXINFO	DBPROCESS is dead or not enabled.
+SYBEDDNE	EXCOMM	DBPROCESS is dead or not enabled.
 SYBEDIVZ	EXUSER	Attempt to divide by $0.00 in function %1!.
 SYBEDNTI	EXPROGRAM	Attempt to use dbtxtsput to put a new text timestamp into a column whose datatype is neither SYBTEXT nor SYBIMAGE.
 SYBEDPOR	EXPROGRAM	Out-of-range datepart constant.

--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -7888,7 +7888,7 @@ static const DBLIB_ERROR_MESSAGE dblib_error_messages[] =
 	, { SYBECUFL,        EXCONVERSION,	"Data conversion resulted in underflow\0" }
 	, { SYBECWLL,           EXPROGRAM,	"Attempt to set column width less than 1\0" }
 	, { SYBEDBPS,          EXRESOURCE,	"Maximum number of DBPROCESSes already allocated\0" }
-	, { SYBEDDNE,              EXINFO,	"DBPROCESS is dead or not enabled\0" }
+	, { SYBEDDNE,              EXCOMM,	"DBPROCESS is dead or not enabled\0" }
 	, { SYBEDIVZ,              EXUSER,	"Attempt to divide by $0.00 in function %1!\0%s" }
 	, { SYBEDNTI,           EXPROGRAM,	"Attempt to use dbtxtsput to put a new text timestamp into a column whose datatype "
 						"is neither SYBTEXT nor SYBIMAGE\0" }

--- a/src/dblib/error_table.h
+++ b/src/dblib/error_table.h
@@ -151,7 +151,7 @@
 {        SYBECWLL,               1,	"Attempt to set column width less than 1."},
 {        SYBEDBPS,      EXRESOURCE,	"Maximum number of DBPROCESSes already allocated."},
 {         SYBEDCL,               1,	"-004- DCL Error."},
-{        SYBEDDNE,          EXINFO,	"DBPROCESS is dead or not enabled."},
+{        SYBEDDNE,          EXCOMM,	"DBPROCESS is dead or not enabled."},
 {        SYBEDIVZ,          EXUSER,	"Attempt to divide by $0.00 in function %1!."},
 {        SYBEDNTI,       EXPROGRAM,	"Attempt to use dbtxtsput() to put a new text-timestamp into a column whose datatype is neither SYBTEXT nor SYBIMAGE."},
 {        SYBEDPOR,       EXPROGRAM,	"Out-of-range datepart constant."},


### PR DESCRIPTION
PR for https://github.com/FreeTDS/freetds/issues/283.
Invalid severity level affects pymssql and possibly other wrappers.
See issue https://github.com/pymssql/pymssql/issues/637 for reference.