### PR TITLE
Fixup/flt8 to decimal convert

### DIFF
--- a/src/tds/convert.c
+++ b/src/tds/convert.c
@@ -1692,7 +1692,7 @@ tds_convert_flt8(const TDS_FLOAT* src, int desttype, CONV_RESULT * cr)
 		break;
 	case SYBNUMERIC:
 	case SYBDECIMAL:
-		sprintf(tmp_str, "%.16g", the_value);
+		sprintf(tmp_str, "%.*f", cr->n.scale, the_value);
 		return stringz_to_numeric(tmp_str, cr);
 		break;
 		/* not allowed */

--- a/src/tds/unittests/convert.c
+++ b/src/tds/unittests/convert.c
@@ -333,7 +333,7 @@ main(int argc, char **argv)
 				srctype, tds_prtype(srctype), srclen,
 				desttype, tds_prtype(desttype));
 
-			if (result == TDS_CONVERT_NOAVAIL)
+			if (result != TDS_CONVERT_NOAVAIL)
 				exit(1);
 		}
 

--- a/src/tds/unittests/convert.c
+++ b/src/tds/unittests/convert.c
@@ -242,7 +242,7 @@ main(int argc, char **argv)
 			srclen = sizeof(tds_uint8);
 			break;
 		case SYBFLT8:
-			tds_float = 3.14159;
+			tds_float = 0.000001;
 			src = (char *) &tds_float;
 			srclen = sizeof(tds_float);
 			break;


### PR DESCRIPTION
Hi @freddy77 

Came across a failure in trying to write a FLOAT to a DECIMAL(p, s) column in SQL SERVER.  I believe I tracked it down to the use of `sprintf(tmp_str, "%.16g", the_value); ` to write the float (source/type) to a string (which is subsequently parsed into a DECIMAL).

In particular, the `%g` conversion specifier seems a little suspect - in my case it was converting my value `0.00001` to `1e-05`, which is not something that `string_to_numeric` is equipped to handle.

Look forward to your feedback. 