### PR TITLE
ignore computed columns when doing bulk copy

### DIFF
--- a/include/freetds/tds.h
+++ b/include/freetds/tds.h
@@ -729,6 +729,7 @@ struct tds_column
 	unsigned char column_hidden:1;
 	unsigned char column_output:1;
 	unsigned char column_timestamp:1;
+	unsigned char column_computed:1;
 	TDS_UCHAR column_collation[5];
 
 	/* additional fields flags for compute results */

--- a/src/tds/bulk.c
+++ b/src/tds/bulk.c
@@ -157,6 +157,7 @@ tds_bcp_init(TDSSOCKET *tds, TDSBCPINFO *bcpinfo)
 		curcol->column_nullable = resinfo->columns[i]->column_nullable;
 		curcol->column_identity = resinfo->columns[i]->column_identity;
 		curcol->column_timestamp = resinfo->columns[i]->column_timestamp;
+		curcol->column_computed = resinfo->columns[i]->column_computed;
 		
 		memcpy(curcol->column_collation, resinfo->columns[i]->column_collation, 5);
 		
@@ -285,6 +286,8 @@ tds_bcp_start_insert_stmt(TDSSOCKET * tds, TDSBCPINFO * bcpinfo)
 				continue;
 			if (!bcpinfo->identity_insert_on && bcpcol->column_identity)
 				continue;
+			if (bcpcol->column_computed)
+				continue;
 			tds7_build_bulk_insert_stmt(tds, &colclause, bcpcol, firstcol);
 			firstcol = 0;
 		}
@@ -359,7 +362,8 @@ tds_bcp_send_record(TDSSOCKET *tds, TDSBCPINFO *bcpinfo, tds_bcp_get_col_data ge
 			 */
 
 			if ((!bcpinfo->identity_insert_on && bindcol->column_identity) || 
-				bindcol->column_timestamp) {
+				bindcol->column_timestamp ||
+				bindcol->column_computed) {
 				continue;
 			}
 
@@ -723,7 +727,8 @@ tds7_bcp_send_colmetadata(TDSSOCKET *tds, TDSBCPINFO *bcpinfo)
 	for (i = 0; i < bcpinfo->bindinfo->num_cols; i++) {
 		bcpcol = bcpinfo->bindinfo->columns[i];
 		if ((!bcpinfo->identity_insert_on && bcpcol->column_identity) || 
-			bcpcol->column_timestamp) {
+			bcpcol->column_timestamp ||
+			bcpcol->column_computed) {
 			continue;
 		}
 		num_cols++;
@@ -743,7 +748,8 @@ tds7_bcp_send_colmetadata(TDSSOCKET *tds, TDSBCPINFO *bcpinfo)
 		 */
 
 		if ((!bcpinfo->identity_insert_on && bcpcol->column_identity) || 
-			bcpcol->column_timestamp) {
+			bcpcol->column_timestamp ||
+			bcpcol->column_computed) {
 			continue;
 		}
 

--- a/src/tds/token.c
+++ b/src/tds/token.c
@@ -1519,6 +1519,7 @@ tds7_get_data_info(TDSSOCKET * tds, TDSCOLUMN * curcol)
 	curcol->column_nullable = curcol->column_flags & 0x01;
 	curcol->column_writeable = (curcol->column_flags & 0x08) > 0;
 	curcol->column_identity = (curcol->column_flags & 0x10) > 0;
+	curcol->column_computed = (curcol->column_flags & 0x20) > 0;
 
 	TDS_GET_COLUMN_TYPE(curcol);	/* sets "cardinal" type */
 


### PR DESCRIPTION
This patch fixes freetds so that it ignores computed columns when doing a bulk insert, in the same manner as with TIMESTAMP columns. Without it, tds_bcp_start_insert_stmt will fail, even if the computed column hasn't been directly specified.

The flag constant for computed columns, 0x20, comes from https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/58880b9f-381c-43b2-bf8b-0727a98c4f4c.