### PR TITLE
tds: Fix for TDS7+ server login and queries

### DIFF
--- a/include/freetds/server.h
+++ b/include/freetds/server.h
@@ -34,17 +34,17 @@ unsigned char *tds7_decrypt_pass(const unsigned char *crypt_pass, int len, unsig
 TDSSOCKET *tds_listen(TDSCONTEXT * ctx, int ip_port);
 int tds_read_login(TDSSOCKET * tds, TDSLOGIN * login);
 int tds7_read_login(TDSSOCKET * tds, TDSLOGIN * login);
-TDSLOGIN *tds_alloc_read_login(TDSSOCKET * tds);
+TDSLOGIN *tds_alloc_read_login(TDSSOCKET * tds, TDS_USMALLINT tds_version);
 
 /* query.c */
 char *tds_get_query(TDSSOCKET * tds);
-char *tds_get_generic_query(TDSSOCKET * tds);
+char *tds_get_generic_query(TDSSOCKET * tds, TDSHEADERS * head);
 
 /* server.c */
 void tds_env_change(TDSSOCKET * tds, int type, const char *oldvalue, const char *newvalue);
 void tds_send_msg(TDSSOCKET * tds, int msgno, int msgstate, int severity, const char *msgtext, const char *srvname,
 		  const char *procname, int line);
-void tds_send_login_ack(TDSSOCKET * tds, const char *progname);
+void tds_send_login_ack(TDSSOCKET * tds, const char *progname, TDS_UINT product_version);
 void tds_send_eed(TDSSOCKET * tds, int msgno, int msgstate, int severity, char *msgtext, char *srvname, char *procname, int line);
 void tds_send_err(TDSSOCKET * tds, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr);
 void tds_send_capabilities_token(TDSSOCKET * tds);

--- a/src/pool/user.c
+++ b/src/pool/user.c
@@ -425,7 +425,7 @@ pool_user_send_login_ack(TDS_POOL * pool, TDS_POOL_USER * puser)
 		tds_put_byte(tds, 0);
 	}
 
-	tds_send_login_ack(tds, mtds->conn->product_name);
+	tds_send_login_ack(tds, mtds->conn->product_name, mtds->conn->product_version);
 	sprintf(block, "%d", tds->conn->env.block_size);
 	tds_env_change(tds, TDS_ENV_PACKSIZE, block, block);
 	/* tds_send_capabilities_token(tds); */

--- a/src/server/login.c
+++ b/src/server/login.c
@@ -310,13 +310,14 @@ tds_read_string(TDSSOCKET * tds, DSTR * s, int size)
  * function should call tds_free_login() on the returned structure when it is
  * no longer needed.
  * \param tds  The socket to read from
+ * \param tds_version  The tds version, if TDS7+
  * \return  Returns NULL if no login was received.  The calling function can
  * use IS_TDSDEAD(tds) to distinguish between an error/shutdown on the socket,
  * or the receipt of an unexpected packet type.  In the latter case,
  * tds->in_flag will indicate the return type.
  */
 TDSLOGIN *
-tds_alloc_read_login(TDSSOCKET * tds)
+tds_alloc_read_login(TDSSOCKET * tds, TDS_USMALLINT tds_version)
 {
 	TDSLOGIN * login;
 
@@ -358,7 +359,7 @@ tds_alloc_read_login(TDSSOCKET * tds)
 		break;
 
 	case TDS71_PRELOGIN: /* TDS7.1+ prelogin, hopefully followed by a login */
-		tds->conn->tds_version = 0x701;
+		tds->conn->tds_version = tds_version ? tds_version : 0x701;
 		/* ignore client and just send our reply TODO... finish */
 		tds71_send_prelogin(tds);
 		tds_flush_packet(tds);

--- a/src/server/query.c
+++ b/src/server/query.c
@@ -78,14 +78,14 @@ tds_get_query_head(TDSSOCKET * tds, TDSHEADERS * head)
 
 	if (IS_TDS72_PLUS(tds->conn)) {
 		int qn_len = 0;
-		const char *qn_msgtext = NULL;
-		const char *qn_options = NULL;
+		char *qn_msgtext = NULL;
+		char *qn_options = NULL;
 		size_t qn_msgtext_len = 0;
 		size_t qn_options_len = 0;
 
 		qn_len = tds_get_int(tds) - 4 - 18;             /* total length */
-		tds_get_int(tds, 18);                          /* length: transaction descriptor, ignored */
-		tds_get_smallint(tds, 2);                      /* type: transaction descriptor, ignored */
+		tds_get_int(tds);                          /* length: transaction descriptor, ignored */
+		tds_get_smallint(tds);                      /* type: transaction descriptor, ignored */
 		tds_get_n(tds, tds->conn->tds72_transaction, 8);  /* transaction */
 		tds_get_int(tds, 1);                           /* request count, ignored */
 		if (qn_len != 0) {
@@ -109,7 +109,7 @@ tds_get_query_head(TDSSOCKET * tds, TDSHEADERS * head)
 			}
 			more = tds->in_len - tds->in_pos;
 			if (more)
-				tds_get_int(tds, head->qn_timeout);        /* timeout */
+				head->qn_timeout = tds_get_int(tds);        /* timeout */
 
 			head->qn_options = qn_options;
 			head->qn_msgtext = qn_msgtext;
@@ -212,7 +212,7 @@ char *tds_get_generic_query(TDSSOCKET * tds, TDSHEADERS * head)
 
 		case TDS_QUERY:
 			/* TDS7+ adds a query head */
-			if (tds_get_query_head(tds, TDS_QUERY, head) != TDS_SUCCESS)
+			if (tds_get_query_head(tds, head) != TDS_SUCCESS)
 				return TDS_FAIL;
 
 			/* TDS4 and TDS7+ fill the whole packet with a query */

--- a/src/server/query.c
+++ b/src/server/query.c
@@ -87,22 +87,22 @@ tds_get_query_head(TDSSOCKET * tds, TDSHEADERS * head)
 		tds_get_int(tds);                          /* length: transaction descriptor, ignored */
 		tds_get_smallint(tds);                      /* type: transaction descriptor, ignored */
 		tds_get_n(tds, tds->conn->tds72_transaction, 8);  /* transaction */
-		tds_get_int(tds, 1);                           /* request count, ignored */
+		tds_get_int(tds);                           /* request count, ignored */
 		if (qn_len != 0) {
 			if (!head) {
 				tds_set_state(tds, TDS_IDLE);
 				return TDS_FAIL;
 			}
 
-			tds_get_int(tds, qn_len);                   /* length: query notification */
+			qn_len = tds_get_int(tds);                   /* length: query notification */
 			tds_get_smallint(tds);                      /* type: query notification, ignored */
-			tds_get_smallint(tds, qn_msgtext_len);  /* notifyid */
+			qn_msgtext_len = tds_get_smallint(tds);  /* notifyid */
 			if (qn_msgtext_len > 0) {
 				qn_msgtext = (char *) realloc(qn_msgtext, qn_msgtext_len);
 				tds_get_n(tds, qn_msgtext, qn_msgtext_len);
 			}
 
-			tds_get_smallint(tds, qn_options_len);  /* ssbdeployment */
+			qn_options_len = tds_get_smallint(tds);  /* ssbdeployment */
 			if (qn_options_len > 0) {
 				qn_options = (char *) realloc(qn_options, qn_options_len);
 				tds_get_n(tds, qn_options, qn_options_len);
@@ -213,7 +213,7 @@ char *tds_get_generic_query(TDSSOCKET * tds, TDSHEADERS * head)
 		case TDS_QUERY:
 			/* TDS7+ adds a query head */
 			if (tds_get_query_head(tds, head) != TDS_SUCCESS)
-				return TDS_FAIL;
+				return NULL;
 
 			/* TDS4 and TDS7+ fill the whole packet with a query */
 			len = 0;

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -159,9 +159,12 @@ tds_send_err(TDSSOCKET * tds, int severity, int dberr, int oserr, char *dberrstr
 }
 
 void
-tds_send_login_ack(TDSSOCKET * tds, const char *progname)
+tds_send_login_ack(TDSSOCKET * tds, const char *progname, TDS_UINT product_version)
 {
 	TDS_UINT ui, version;
+
+	/* connections from SSMS require product_version */
+	tds->conn->product_version = product_version;
 
 	tds_put_byte(tds, TDS_LOGINACK_TOKEN);
 	tds_put_smallint(tds, 10 + (IS_TDS7_PLUS(tds->conn)? 2 : 1) * strlen(progname));	/* length of message */

--- a/src/server/unittest.c
+++ b/src/server/unittest.c
@@ -59,7 +59,7 @@ main(int argc, char **argv)
 	if (!tds)
 		return 1;
 	/* get_incoming(tds->s); */
-	login = tds_alloc_read_login(tds);
+	login = tds_alloc_read_login(tds, 0x702);
 	if (!login) {
 		fprintf(stderr, "Error reading login\n");
 		exit(1);
@@ -68,14 +68,14 @@ main(int argc, char **argv)
 	if (!strcmp(tds_dstr_cstr(&login->user_name), "guest") && !strcmp(tds_dstr_cstr(&login->password), "sybase")) {
 		tds->out_flag = TDS_REPLY;
 		tds_env_change(tds, TDS_ENV_DATABASE, "master", "pubs2");
-		tds_send_msg(tds, 5701, 2, 10, "Changed database context to 'pubs2'.", "JDBC", "ZZZZZ", 1);
+		//tds_send_msg(tds, 5701, 2, 10, "Changed database context to 'pubs2'.", "JDBC", "ZZZZZ", 1);
 		if (!login->suppress_language) {
 			tds_env_change(tds, TDS_ENV_LANG, NULL, "us_english");
-			tds_send_msg(tds, 5703, 1, 10, "Changed language setting to 'us_english'.", "JDBC", "ZZZZZ", 1);
+			//tds_send_msg(tds, 5703, 1, 10, "Changed language setting to 'us_english'.", "JDBC", "ZZZZZ", 1);
 		}
 		tds_env_change(tds, TDS_ENV_PACKSIZE, NULL, "512");
 		/* TODO set mssql if tds7+ */
-		tds_send_login_ack(tds, "sql server");
+		tds_send_login_ack(tds, "sql server", TDS_MS_VER(10, 0, 6000));
 		if (IS_TDS50(tds->conn))
 			tds_send_capabilities_token(tds);
 		tds_send_done_token(tds, 0, 1);
@@ -87,7 +87,7 @@ main(int argc, char **argv)
 	tds_free_login(login);
 	login = NULL;
 	/* printf("incoming packet %d\n", tds_read_packet(tds)); */
-	printf("query : %s\n", tds_get_generic_query(tds));
+	printf("query : %s\n", tds_get_generic_query(tds, NULL));
 	tds->out_flag = TDS_REPLY;
 	resinfo = tds_alloc_results(1);
 	resinfo->columns[0]->column_type = SYBVARCHAR;

--- a/src/server/unittest.c
+++ b/src/server/unittest.c
@@ -68,10 +68,10 @@ main(int argc, char **argv)
 	if (!strcmp(tds_dstr_cstr(&login->user_name), "guest") && !strcmp(tds_dstr_cstr(&login->password), "sybase")) {
 		tds->out_flag = TDS_REPLY;
 		tds_env_change(tds, TDS_ENV_DATABASE, "master", "pubs2");
-		//tds_send_msg(tds, 5701, 2, 10, "Changed database context to 'pubs2'.", "JDBC", "ZZZZZ", 1);
+		tds_send_msg(tds, 5701, 2, 10, "Changed database context to 'pubs2'.", "JDBC", "ZZZZZ", 1);
 		if (!login->suppress_language) {
 			tds_env_change(tds, TDS_ENV_LANG, NULL, "us_english");
-			//tds_send_msg(tds, 5703, 1, 10, "Changed language setting to 'us_english'.", "JDBC", "ZZZZZ", 1);
+			tds_send_msg(tds, 5703, 1, 10, "Changed language setting to 'us_english'.", "JDBC", "ZZZZZ", 1);
 		}
 		tds_env_change(tds, TDS_ENV_PACKSIZE, NULL, "512");
 		/* TODO set mssql if tds7+ */


### PR DESCRIPTION
TDS connections from Microsoft products require TDS72+, and SSMS requires product_version. Previously all TDS71+ became TDS71.
TDS72+ query adds a query head.

Signed-off-by: Sky Morey <smorey@degdigital.com>

Server connection from .net sql connector, or SSMS studio, required a newer TDS.
Open to reworking or regrouping these changes as needed.