### PR TITLE
odbc: SQLColumns: Ability to operate out-of-catalog

### DIFF
--- a/doc/userguide.xml
+++ b/doc/userguide.xml
@@ -1766,7 +1766,7 @@ The server responds with a port number.
 				<filename>PWD</filename> holds a username, password, servername, and database to be used for the unit tests.  We try to make sure to leave nothing behind: any data and objects created are either temporary or removed at the end of the test.  The tests should all work, subject to disclaimers in the directory's <filename>README</filename>.</para>
 
 <para>To invoke the tests, edit the <filename>PWD</filename> file and issue the command <command>make check</command>.  In order to execute all tests successfully, you must indicate a working, available servername in <filename>PWD</filename>.
-				Some tests require permission to create stored procedures on server.</para>
+				Some tests require permission to create stored procedures on server.  In addition, some may require that a database named <literal>freetds_test</literal> exists on the server, and the user whose credentials are used during the testing process has sufficient permissions to create and manipulate tables in this database.</para>
 
 <para>To complete successfully, the ODBC tests require some additional setup.
 In your <filename>PWD</filename> file, add a <literal>SRV</literal> entry specifying the DSN entry for your <filename>odbc.ini</filename>.

--- a/misc/appveyor.yml
+++ b/misc/appveyor.yml
@@ -125,6 +125,8 @@ test_script:
   - set INSTANCENAME=SQL2016
   - "powershell misc\\sql-server-activate-tcp-fixed-port.ps1"
   # Create freetds.conf
+  # Create a test database
+  - sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE freetds_test"
   - cd build_debug
   - echo [global]> freetds.conf.local
   - echo port = 1433>> freetds.conf.local

--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -4785,24 +4785,12 @@ ODBC_FUNC(SQLColumns, (P(SQLHSTMT,hstmt), PCHARIN(CatalogName,SQLSMALLINT),	/* o
 	WIDE))
 {
 	int retcode;
-	DSTR catalog_name = DSTR_INITIALIZER;
-	SQLSMALLINT catalog_size;
-	const char *proc = NULL;
+	const char *proc = "sp_columns";
 
 	ODBC_ENTER_HSTMT;
 
-	if (cbCatalogName == SQL_NTS) {
-		if (!odbc_dstr_copy(stmt->dbc, &catalog_name, cbCatalogName, szCatalogName))
-			goto memory_error;
-		catalog_size = tds_dstr_len(&catalog_name);
-	} else {
-		catalog_size = cbCatalogName;
-	}
-
-	proc = "sp_columns";
-	if (catalog_size > 0) {
+	if (odbc_get_string_size(cbCatalogName, szCatalogName _wide))
 		proc = "..sp_columns";
-	}
 
 	retcode =
 		odbc_stat_execute(stmt _wide, proc, TDS_IS_MSSQL(stmt->dbc->tds_socket) ? 5 : 4,
@@ -4819,13 +4807,6 @@ ODBC_FUNC(SQLColumns, (P(SQLHSTMT,hstmt), PCHARIN(CatalogName,SQLSMALLINT),	/* o
 		if (TDS_IS_SYBASE(stmt->dbc->tds_socket))
 			stmt->special_row = ODBC_SPECIAL_COLUMNS;
 	}
-
-	tds_dstr_free(&catalog_name);
-	ODBC_EXIT_(stmt);
-
-memory_error:
-	tds_dstr_free(&catalog_name);
-	odbc_errs_add(&stmt->errs, "HY001", NULL);
 	ODBC_EXIT_(stmt);
 }
 

--- a/src/odbc/unittests/stats.c
+++ b/src/odbc/unittests/stats.c
@@ -14,8 +14,6 @@ ReadCol(int i)
 	CHKGetData(i, SQL_C_CHAR, output, sizeof(output), &cnamesize, "S");
 }
 
-static const char *catalog = NULL;
-static const char *schema = NULL;
 static const char *proc = "stat_proc";
 static const char *table = "stat_proc";
 static const char *column = "@t";
@@ -23,9 +21,10 @@ static const char *column = "@t";
 #define LEN(x) (x) ? strlen(x) : 0
 
 static void
-TestProc(const char *type, const char *expected)
+TestProc(const char *catalog, const char *type, const char *expected)
 {
 	char sql[256];
+	char *schema = NULL;
 
 	odbc_command("IF OBJECT_ID('stat_proc') IS NOT NULL DROP PROC stat_proc");
 
@@ -49,13 +48,25 @@ TestProc(const char *type, const char *expected)
 }
 
 static void
-TestTable(const char *type, const char *expected)
+TestTable(const char *catalog, const char *type, const char *expected)
 {
 	char sql[256];
+	char *schema = NULL;
 
-	odbc_command("IF OBJECT_ID('stat_t') IS NOT NULL DROP TABLE stat_t");
+	if (catalog) {
+		schema = "dbo";
+		sprintf(sql, "DROP DATABASE IF EXISTS %s", catalog);
+		odbc_command(sql);
+		sprintf(sql, "CREATE DATABASE %s", catalog);
+		odbc_command(sql);
+		sprintf(sql, "IF OBJECT_ID('%s.%s.stat_t') IS NOT NULL DROP TABLE %s.%s.stat_t", catalog, schema, catalog, schema);
+		odbc_command(sql);
+		sprintf(sql, "CREATE TABLE %s.%s.stat_t(t %s)", catalog, schema, type);
+	} else {
+		odbc_command("IF OBJECT_ID('stat_t') IS NOT NULL DROP TABLE stat_t");
+		sprintf(sql, "CREATE TABLE stat_t(t %s)", type);
+	}
 
-	sprintf(sql, "CREATE TABLE stat_t(t %s)", type);
 	odbc_command(sql);
 
 	column = "t";
@@ -72,6 +83,10 @@ TestTable(const char *type, const char *expected)
 	}
 
 	CHKCloseCursor("SI");
+	if (catalog) {
+		sprintf(sql, "DROP DATABASE IF EXISTS %s", catalog);
+		odbc_command(sql);
+	}
 	ODBC_FREE();
 }
 
@@ -93,8 +108,9 @@ main(int argc, char *argv[])
 	odbc_use_version3 = 0;
 	odbc_connect();
 
-	TestProc("DATETIME", STR(SQL_TIMESTAMP));
-	TestTable("DATETIME", STR(SQL_TIMESTAMP));
+	TestProc(NULL, "DATETIME", STR(SQL_TIMESTAMP));
+	TestTable(NULL, "DATETIME", STR(SQL_TIMESTAMP));
+	TestTable("testdb", "DATETIME", STR(SQL_TIMESTAMP));
 
 	odbc_disconnect();
 
@@ -102,8 +118,9 @@ main(int argc, char *argv[])
 	odbc_use_version3 = 1;
 	odbc_connect();
 
-	TestProc("DATETIME", STR(SQL_TYPE_TIMESTAMP));
-	TestTable("DATETIME", STR(SQL_TYPE_TIMESTAMP));
+	TestProc(NULL, "DATETIME", STR(SQL_TYPE_TIMESTAMP));
+	TestTable(NULL, "DATETIME", STR(SQL_TYPE_TIMESTAMP));
+	TestTable("testdb", "DATETIME", STR(SQL_TYPE_TIMESTAMP));
 
 	odbc_disconnect();
 

--- a/src/odbc/unittests/stats.c
+++ b/src/odbc/unittests/stats.c
@@ -55,10 +55,6 @@ TestTable(const char *catalog, const char *type, const char *expected)
 
 	if (catalog) {
 		schema = "dbo";
-		sprintf(sql, "DROP DATABASE IF EXISTS %s", catalog);
-		odbc_command(sql);
-		sprintf(sql, "CREATE DATABASE %s", catalog);
-		odbc_command(sql);
 		sprintf(sql, "IF OBJECT_ID('%s.%s.stat_t') IS NOT NULL DROP TABLE %s.%s.stat_t", catalog, schema, catalog, schema);
 		odbc_command(sql);
 		sprintf(sql, "CREATE TABLE %s.%s.stat_t(t %s)", catalog, schema, type);
@@ -83,10 +79,6 @@ TestTable(const char *catalog, const char *type, const char *expected)
 	}
 
 	CHKCloseCursor("SI");
-	if (catalog) {
-		sprintf(sql, "DROP DATABASE IF EXISTS %s", catalog);
-		odbc_command(sql);
-	}
 	ODBC_FREE();
 }
 
@@ -110,7 +102,7 @@ main(int argc, char *argv[])
 
 	TestProc(NULL, "DATETIME", STR(SQL_TIMESTAMP));
 	TestTable(NULL, "DATETIME", STR(SQL_TIMESTAMP));
-	TestTable("testdb", "DATETIME", STR(SQL_TIMESTAMP));
+	TestTable("freetds_test", "DATETIME", STR(SQL_TIMESTAMP));
 
 	odbc_disconnect();
 
@@ -120,7 +112,7 @@ main(int argc, char *argv[])
 
 	TestProc(NULL, "DATETIME", STR(SQL_TYPE_TIMESTAMP));
 	TestTable(NULL, "DATETIME", STR(SQL_TYPE_TIMESTAMP));
-	TestTable("testdb", "DATETIME", STR(SQL_TYPE_TIMESTAMP));
+	TestTable("freetds_test", "DATETIME", STR(SQL_TYPE_TIMESTAMP));
 
 	odbc_disconnect();
 


### PR DESCRIPTION
Hi @freddy77 

Currently I am unable to execute an out-of-current-catalog call to `SQLColumns`.  To highlight this in an example, I modified one of the unit-tests [here](https://github.com/detule/freetds/commit/34ec69e7e07d28f40c962e21b435ad01c72205d2) (unit test mod not submitted here as part of the PR).

With this  patch, we call `catalog.sp_columns` (catalog sproc, rather than system sproc), whenever a non-trivial catalog is supplied.

* I am not sure how sybase would be affected - happy to guard the added code inside an `if MSSQL` block if you think that's appropriate.
* Also happy to submit this mod or another unit test for this functionality.

Look forward to getting your feedback.