### PR TITLE
Fix datacopy logging

### DIFF
--- a/src/apps/datacopy.c
+++ b/src/apps/datacopy.c
@@ -236,7 +236,7 @@ process_parameters(int argc, char **argv, BCPPARAMDATA * pdata)
 			pdata->owner = strdup(optarg);
 			break;
 		case 'd':
-			tdsdump_open(NULL);
+			tdsdump_open("stderr");
 			break;
 		case 'S':
 			pdata->Sflag++;


### PR DESCRIPTION
Use stderr for logging when it's enabled instead of discarding logs.