### PR TITLE
Fix defncopy error when displaying length of variable types

### DIFF
--- a/include/sybdb.h
+++ b/include/sybdb.h
@@ -572,6 +572,7 @@ typedef int (*MHANDLEFUNC) (DBPROCESS * dbproc, DBINT msgno, int msgstate, int s
 
 #define DBPRCOLSEP  21
 #define DBPRLINELEN 22
+#define DBRPCNORETURN 0
 #define DBRPCRETURN 1
 #define DBRPCDEFAULT 2
 

--- a/src/apps/defncopy.c
+++ b/src/apps/defncopy.c
@@ -455,19 +455,19 @@ print_ddl(DBPROCESS *dbproc, PROCEDURE *procedure)
 
 				if ((i == 2) && (dbcoltype(dbproc, colmap[i]) != SYBINT4)) { // Sybase's sp_help returns the length as CHAR(6)
 					DBCHAR *p = (DBCHAR*) dbdata(dbproc, colmap[i]) + datlen -1;
-					for (int j = 0, pow = 1; j < datlen && *p != ' '; j++, pow*=10) { //converts char(6) to integer
+					for (int j = 0, pow = 1; j < datlen && *p != ' '; j++, pow *= 10) { //converts char(6) to integer
 						len += (*(p--) - '0') * pow;
 					}
 				}
 
-				*coldesc[i] = (char *)calloc(1, (len > 0) ? sizeof(SYBINT4) : (1 + datlen)); /* calloc will null terminate */
+				*coldesc[i] = (char *)calloc(1, (len > 0) ? sizeof(int) : (1 + datlen)); /* calloc will null terminate */
 				if (*coldesc[i] == NULL) {
 					perror("error: insufficient memory for row detail");
 					assert(*coldesc[i] != NULL);
 					exit(1);
 				}
 				if (len > 0)
-					memcpy(*coldesc[i], &len, sizeof(SYBINT4));
+					memcpy(*coldesc[i], &len, sizeof(int));
 				else
 					memcpy(*coldesc[i], dbdata(dbproc, colmap[i]), datlen);
 

--- a/src/apps/defncopy.c
+++ b/src/apps/defncopy.c
@@ -454,20 +454,21 @@ print_ddl(DBPROCESS *dbproc, PROCEDURE *procedure)
 				}
 
 				if ((i == 2) && (dbcoltype(dbproc, colmap[i]) != SYBINT4)) { // Sybase's sp_help returns the length as CHAR(6)
-					DBCHAR *p = (DBCHAR*) dbdata(dbproc, colmap[i]) + datlen -1;
-					for (int j = 0, pow = 1; j < datlen && *p != ' '; j++, pow *= 10) { //converts char(6) to integer
+					int j, pow;
+					DBCHAR *p = (DBCHAR*) dbdata(dbproc, colmap[i]) + datlen - 1;
+					for (j = 0, pow = 1; j < datlen && *p != ' '; j++, pow *= 10) { //converts char(6) to integer
 						len += (*(p--) - '0') * pow;
 					}
 				}
 
-				*coldesc[i] = (char *)calloc(1, (len > 0) ? sizeof(int) : (1 + datlen)); /* calloc will null terminate */
+				*coldesc[i] = (char *)calloc(1, (len > 0) ? sizeof(len) : (1 + datlen)); /* calloc will null terminate */
 				if (*coldesc[i] == NULL) {
 					perror("error: insufficient memory for row detail");
 					assert(*coldesc[i] != NULL);
 					exit(1);
 				}
 				if (len > 0)
-					memcpy(*coldesc[i], &len, sizeof(int));
+					memcpy(*coldesc[i], &len, sizeof(len));
 				else
 					memcpy(*coldesc[i], dbdata(dbproc, colmap[i]), datlen);
 


### PR DESCRIPTION
defncopy doesn't display the correct length of variable types (VARCHAR, CHAR, TEXT...) because Sybase ASE's sp_help displays the length field as CHAR(6) when MSSQL outputs it as integer. Added a condition to check and do the conversion if necessary (used MSSQL behavior as reference so as not to break the code after, which assumes the length is an integer).