### PR TITLE
Keep make from failing if the source path contains spaces.

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -112,7 +112,7 @@ $(DOCDIR)/userguide/index.html: 	$(DOCDIR) userguide.xml userguide_desc.xml \
 		fi; \
 	fi
 # try xmlto ...
-	test -r $(abs_srcdir)/userguide.xml
+	test -r "$(abs_srcdir)/userguide.xml"
 	test -r userguide.xml || ln -s $(srcdir)/userguide.xml userguide.xml
 	test -r userguide.xsl || ln -s $(srcdir)/userguide.xsl userguide.xsl
 	test -r userguide_desc.xml || ln -s $(srcdir)/userguide_desc.xml userguide_desc.xml
@@ -120,7 +120,7 @@ $(DOCDIR)/userguide/index.html: 	$(DOCDIR) userguide.xml userguide_desc.xml \
 	if xmlto --version > /dev/null 2> /dev/null ; then \
 		xmlto -m ../userguide.xsl xhtml ../userguide.xml; \
 ## 		and copy the stylesheet
-		cp $(abs_srcdir)/userguide.css .; \
+		cp "$(abs_srcdir)/userguide.css" .; \
 	fi)
 # if still no joy, create a stub
 	if test ! -r $@ ; then \

--- a/src/ctlib/unittests/Makefile.am
+++ b/src/ctlib/unittests/Makefile.am
@@ -85,7 +85,7 @@ AM_CPPFLAGS	=	-I$(top_srcdir)/include
 if MINGW32
 AM_LDFLAGS	=	-no-fast-install
 else
-AM_LDFLAGS	=	-no-install -L../.libs -R $(abs_builddir)/../.libs
+AM_LDFLAGS	=	-no-install -L../.libs -R "$(abs_builddir)/../.libs"
 endif
 LDADD		=	libcommon.a ../libct.la ../../replacements/libreplacements.la $(LTLIBICONV)
 CLEANFILES	=	tdsdump.out

--- a/src/dblib/unittests/Makefile.am
+++ b/src/dblib/unittests/Makefile.am
@@ -106,7 +106,7 @@ AM_CPPFLAGS	= 	-DFREETDS_TOPDIR=\"$(top_srcdir)\" -I$(top_srcdir)/include
 if MINGW32
 AM_LDFLAGS	=	-no-fast-install
 else
-AM_LDFLAGS	=	-no-install -L../.libs -R $(abs_builddir)/../.libs
+AM_LDFLAGS	=	-no-install -L../.libs -R "$(abs_builddir)/../.libs"
 endif
 LDADD		=	libcommon.a ../libsybdb.la ../../replacements/libreplacements.la $(LTLIBICONV)
 EXTRA_DIST	=	CMakeLists.txt

--- a/src/odbc/unittests/Makefile.am
+++ b/src/odbc/unittests/Makefile.am
@@ -189,7 +189,7 @@ endif
 if MINGW32
 AM_LDFLAGS	=	-no-fast-install
 else
-AM_LDFLAGS	=	-no-install -L../.libs -R $(abs_builddir)/../.libs
+AM_LDFLAGS	=	-no-install -L../.libs -R "$(abs_builddir)/../.libs"
 endif
 LDADD		=	libcommon.a $(ODBC_LDFLAGS) ../../replacements/libreplacements.la $(GLOBAL_LD_ADD)
 DISTCLEANFILES	=	odbc.ini odbcinst.ini

--- a/src/tds/unittests/Makefile.am
+++ b/src/tds/unittests/Makefile.am
@@ -74,7 +74,7 @@ AM_CPPFLAGS	=	-I$(top_srcdir)/include -I$(srcdir)/.. -I../ -DFREETDS_TOPDIR=\"$(
 if MINGW32
 AM_LDFLAGS	=	-no-fast-install
 else
-AM_LDFLAGS	=	-no-install -L../.libs -R $(abs_builddir)/../.libs
+AM_LDFLAGS	=	-no-install -L../.libs -R "$(abs_builddir)/../.libs"
 endif
 LDADD		=	libcommon.a ../libtds.la ../../replacements/libreplacements.la $(LTLIBICONV) $(NETWORK_LIBS)
 CLEANFILES	=	tdsdump.out


### PR DESCRIPTION
Currently when building freetds the build fails if the build path has spaces in its name. This fixes the issue for me.