### PR TITLE
encryption=request should attempt encryption

### DIFF
--- a/src/tds/login.c
+++ b/src/tds/login.c
@@ -1281,7 +1281,7 @@ tds71_do_login(TDSSOCKET * tds, TDSLOGIN* login)
 	   tests for TDS_ENCRYPTION_DEFAULT.
 	*/
 	tds_put_byte(tds, encryption_level == TDS_ENCRYPTION_OFF ? TDS7_ENCRYPT_NOT_SUP :
-			  encryption_level >= TDS_ENCRYPTION_REQUIRE ? TDS7_ENCRYPT_ON :
+			  encryption_level >= TDS_ENCRYPTION_REQUEST ? TDS7_ENCRYPT_ON :
 			  TDS7_ENCRYPT_OFF);
 #endif
 	/* instance */
@@ -1373,4 +1373,3 @@ tds71_do_login(TDSSOCKET * tds, TDSLOGIN* login)
 
 	return ret;
 }
-


### PR DESCRIPTION
I am new to FreeTDS, but this PR came from trying to understand why my client server setup (with no other changes), never connects with encryption (when `encryption=request`). However, a new connection is established with Encryption, by (merely) changing `encryption=require`.

That led me to think that currently the code is such that if `encryption_level != Off` then only `TDS_ENCRYPTION_REQUIRE` (or higher) ends up with `TDS7_ENCRYPT_ON`. Shouldn't it include `TDS_ENCRYPTION_REQUEST` too? - Here I assume that `TDS_ENCRYPTION_REQUEST < TDS_ENCRYPTION_REQUEST` based off of [this line](https://github.com/FreeTDS/freetds/blob/master/include/freetds/tds.h#L336).

I use this Query to check whether Encryption is currently enabled:
```
CREATE FOREIGN TABLE v
  (
    client_net_address text,
    net_transport text,
    encrypt_option text,
    auth_scheme text
  )
  SERVER tdsdb
  OPTIONS (query 'SELECT client_net_address, net_transport, encrypt_option, auth_scheme FROM sys.dm_exec_connections WHERE auth_scheme = ''SQL''');
```

With the above in place, and `encryption = require` in FreeTDS, we see that:
```
tds=> table v;
NOTICE:  tds_fdw: Query executed correctly
NOTICE:  tds_fdw: Getting results
 client_net_address | net_transport | encrypt_option | auth_scheme
--------------------+---------------+----------------+-------------
 1.2.3.4            | TCP           | TRUE           | SQL
(1 row)
```

However, if I set `encryption=request` and restart Postgres, I see this:
```
tds=> select 1;
FATAL:  terminating connection due to administrator command
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
The connection to the server was lost. Attempting reset: Succeeded.
psql (13.4, server 14.1)
tds=> table v;
NOTICE:  tds_fdw: Query executed correctly
NOTICE:  tds_fdw: Getting results
 client_net_address | net_transport | encrypt_option | auth_scheme
--------------------+---------------+----------------+-------------
 1.2.3.4            | TCP           | FALSE          | SQL
(1 row)
```