### PR TITLE
build-sys: fix out-of-tree mingw compilation

### DIFF
--- a/src/odbc/Makefile.am
+++ b/src/odbc/Makefile.am
@@ -22,7 +22,7 @@ libtdsodbc_la_LIBADD +=	setup.res
 libtdsodbc_la_LDFLAGS += -Wl,--kill-at -Wl,--enable-stdcall-fixup -Wl,-s -Wl,@srcdir@/odbc_w.def -Wl,setup.res
 
 .rc.res:
-	$(RC) -i $< --input-format=rc -o $@ -O coff
+	$(RC) -i $< --input-format=rc -o $@ -O coff -I @builddir@
 else
 if !MACOSX
 libtdsodbc_la_LDFLAGS += -export-symbols-regex '^(SQL|ODBCINST).*'


### PR DESCRIPTION
```
x86_64-w64-mingw32-windres -i ../../../src/odbc/setup.rc --input-format=rc -o setup.res -O coff
../../../src/odbc/setup.rc:19:10: fatal error: version.rc: No such file or directory
   19 | #include "version.rc"
      |          ^~~~~~~~~~~~
```