### PR TITLE
Allow embedded braces in connection-string values

### DIFF
--- a/src/odbc/unittests/.gitignore
+++ b/src/odbc/unittests/.gitignore
@@ -85,3 +85,4 @@ transaction3
 transaction4
 utf8_4
 qn
+connection_string_parse

--- a/src/odbc/unittests/CMakeLists.txt
+++ b/src/odbc/unittests/CMakeLists.txt
@@ -29,7 +29,7 @@ set(tests
 	array_error closestmt bcp
 	all_types utf8_3 empty_query
 	transaction3 transaction4
-	utf8_4 qn
+	utf8_4 qn connection_string_parse
 )
 
 if(WIN32)
@@ -40,7 +40,7 @@ endif()
 
 add_library(o_common STATIC common.c common.h c2string.c parser.c parser.h)
 
-set(static_tests all_types utf8_4)
+set(static_tests all_types utf8_4 connection_string_parse)
 set(unicode_tests utf8 oldpwd)
 foreach(target ${tests})
 	add_executable(o_${target} EXCLUDE_FROM_ALL ${target}.c)

--- a/src/odbc/unittests/Makefile.am
+++ b/src/odbc/unittests/Makefile.am
@@ -81,6 +81,7 @@ TESTS =	\
 	transaction4$(EXEEXT) \
 	utf8_4$(EXEEXT) \
 	qn$(EXEEXT) \
+	connection_string_parse$(EXEEXT) \
 	$(NULL)
 
 check_PROGRAMS	=	$(TESTS) oldpwd$(EXEEXT)
@@ -175,6 +176,9 @@ empty_query_SOURCES = empty_query.c
 transaction3_SOURCES = transaction3.c
 transaction4_SOURCES = transaction4.c
 qn_SOURCES = qn.c
+connection_string_parse_SOURCES = connection_string_parse.c
+connection_string_parse_CPPFLAGS = $(GLOBAL_CPPFLAGS)
+connection_string_parse_LDFLAGS = -static ../libtdsodbc.la ../../tds/unittests/libcommon.a -shared $(GLOBAL_LD_ADD)
 
 noinst_LIBRARIES = libcommon.a
 libcommon_a_SOURCES = common.c common.h

--- a/src/odbc/unittests/connection_string_parse.c
+++ b/src/odbc/unittests/connection_string_parse.c
@@ -1,0 +1,206 @@
+#include "common.h"
+#include <assert.h>
+#include "freetds/odbc.h"
+
+
+#ifdef _WIN32
+HINSTANCE hinstFreeTDS;
+#endif
+
+static void
+assert_equal_dstr(DSTR a, const char *b)
+{
+	assert(b && strcmp(tds_dstr_cstr(&a), b)==0);
+}
+
+static void
+assert_equal_str(TDS_PARSED_PARAM param, const char *b)
+{
+	/* printf("param %.*s b %s\n", (int) param.len, param.p, b); */
+	assert(b && strlen(b) == param.len && strncmp(param.p, b, param.len)==0);
+}
+
+static int
+simple_string(void)
+{
+	TDSLOGIN *login;
+	TDS_ERRS errs = {0};
+	TDSLOCALE *locale;
+	TDS_PARSED_PARAM parsed_params[ODBC_PARAM_SIZE];
+	const char *connect_string = "DRIVER=libtdsodbc.so;SERVER=127.0.0.1;PORT=1337;UID=test_username;PWD=test_password;DATABASE=test_db;ClientCharset=UTF-8;";
+
+	const char *connect_string_end = connect_string + strlen(connect_string);
+	login = tds_alloc_login(0);
+	tds_set_language(login, "us_english");
+	locale = tds_alloc_locale();
+	login = tds_init_login(login, locale);
+
+	odbc_errs_reset(&errs);
+
+	if (!odbc_parse_connect_string(&errs, connect_string, connect_string_end, login, parsed_params))
+		return 1;
+
+	assert_equal_str(parsed_params[ODBC_PARAM_UID], "test_username");
+	assert_equal_dstr(login->server_name, "127.0.0.1");
+	assert_equal_dstr(login->password, "test_password");
+	assert_equal_str(parsed_params[ODBC_PARAM_PWD], "test_password");
+	assert(login->port == 1337);
+
+	tds_free_login(login);
+	tds_free_locale(locale);
+
+	return 0;
+}
+
+static int
+simple_escaped_string(void)
+{
+	TDSLOGIN *login;
+	TDS_ERRS errs = {0};
+	TDSLOCALE *locale;
+	TDS_PARSED_PARAM parsed_params[ODBC_PARAM_SIZE];
+	const char *connect_string = "DRIVER={libtdsodbc.so};SERVER={127.0.0.1};PORT={1337};UID={test_username};PWD={test_password};DATABASE={test_db};ClientCharset={UTF-8};";
+
+	const char *connect_string_end = connect_string + strlen(connect_string);
+	login = tds_alloc_login(0);
+	tds_set_language(login, "us_english");
+	locale = tds_alloc_locale();
+	login = tds_init_login(login, locale);
+
+	odbc_errs_reset(&errs);
+
+	if (!odbc_parse_connect_string(&errs, connect_string, connect_string_end, login, parsed_params))
+		return 1;
+
+	assert_equal_str(parsed_params[ODBC_PARAM_UID], "{test_username}");
+	assert_equal_dstr(login->server_name, "127.0.0.1");
+	assert_equal_dstr(login->password, "test_password");
+	assert_equal_str(parsed_params[ODBC_PARAM_PWD], "{test_password}");
+	assert(login->port == 1337);
+
+	tds_free_login(login);
+	tds_free_locale(locale);
+
+	return 0;
+}
+
+static int
+test_special_symbols(void)
+{
+	TDSLOGIN *login;
+	TDS_ERRS errs = {0};
+	TDSLOCALE *locale;
+	TDS_PARSED_PARAM parsed_params[ODBC_PARAM_SIZE];
+	const char *connect_string = "DRIVER={libtdsodbc.so};SERVER={127.0.0.1};PORT={1337};UID={test_username};PWD={[]{}}(),;?*=!@};DATABASE={test_db};ClientCharset={UTF-8};";
+
+	const char *connect_string_end = connect_string + strlen(connect_string);
+	login = tds_alloc_login(0);
+	tds_set_language(login, "us_english");
+	locale = tds_alloc_locale();
+	login = tds_init_login(login, locale);
+
+	odbc_errs_reset(&errs);
+
+	if (!odbc_parse_connect_string(&errs, connect_string, connect_string_end, login, parsed_params))
+		return 1;
+
+	assert_equal_str(parsed_params[ODBC_PARAM_UID], "{test_username}");
+	assert_equal_dstr(login->server_name, "127.0.0.1");
+	assert_equal_dstr(login->password, "[]{}(),;?*=!@");
+	assert_equal_str(parsed_params[ODBC_PARAM_PWD], "{[]{}}(),;?*=!@}");
+	assert(login->port == 1337);
+
+	tds_free_login(login);
+	tds_free_locale(locale);
+
+	return 0;
+}
+
+static int
+password_contains_curly_braces(void)
+{
+	TDSLOGIN *login;
+	TDS_ERRS errs = {0};
+	TDSLOCALE *locale;
+	TDS_PARSED_PARAM parsed_params[ODBC_PARAM_SIZE];
+	const char *connect_string = "DRIVER={libtdsodbc.so};SERVER={127.0.0.1};PORT={1337};UID={test_username};PWD={test{}}_password};DATABASE={test_db};ClientCharset={UTF-8};";
+
+	const char *connect_string_end = connect_string + strlen(connect_string);
+	login = tds_alloc_login(0);
+	tds_set_language(login, "us_english");
+	locale = tds_alloc_locale();
+	login = tds_init_login(login, locale);
+
+	odbc_errs_reset(&errs);
+
+	if (!odbc_parse_connect_string(&errs, connect_string, connect_string_end, login, parsed_params))
+		return 1;
+
+	assert_equal_str(parsed_params[ODBC_PARAM_UID], "{test_username}");
+	assert_equal_dstr(login->server_name, "127.0.0.1");
+	assert_equal_dstr(login->password, "test{}_password");
+	assert_equal_str(parsed_params[ODBC_PARAM_PWD], "{test{}}_password}");
+	assert(login->port == 1337);
+
+	tds_free_login(login);
+	tds_free_locale(locale);
+
+	return 0;
+}
+
+static int
+password_contains_curly_braces_and_separator(void)
+{
+	TDSLOGIN *login;
+	TDS_ERRS errs = {0};
+	TDSLOCALE *locale;
+	TDS_PARSED_PARAM parsed_params[ODBC_PARAM_SIZE];
+	const char *connect_string = "DRIVER={libtdsodbc.so};SERVER={127.0.0.1};PORT={1337};UID={test_username};PWD={test{}};_password};DATABASE={test_db};ClientCharset={UTF-8};";
+
+	const char *connect_string_end = connect_string + strlen(connect_string);
+	login = tds_alloc_login(0);
+	tds_set_language(login, "us_english");
+	locale = tds_alloc_locale();
+	login = tds_init_login(login, locale);
+
+	odbc_errs_reset(&errs);
+
+	if (!odbc_parse_connect_string(&errs, connect_string, connect_string_end, login, parsed_params))
+		return 1;
+
+	assert_equal_str(parsed_params[ODBC_PARAM_UID], "{test_username}");
+	assert_equal_dstr(login->server_name, "127.0.0.1");
+	assert_equal_dstr(login->password, "test{};_password");
+	assert_equal_str(parsed_params[ODBC_PARAM_PWD], "{test{}};_password}");
+	assert(login->port == 1337);
+
+	tds_free_login(login);
+	tds_free_locale(locale);
+
+	return 0;
+}
+
+
+int main(int argc, char *argv[])
+{
+#ifdef _WIN32
+	hinstFreeTDS = GetModuleHandle(NULL);
+#endif
+
+	if (simple_string() != 0)
+		return 1;
+
+	if (simple_escaped_string() != 0)
+		return 1;
+
+	if (password_contains_curly_braces() != 0)
+		return 1;
+
+	if (test_special_symbols() != 0)
+		return 1;
+
+	if (password_contains_curly_braces_and_separator() != 0)
+		return 1;
+
+	return 0;
+}


### PR DESCRIPTION
We've encountered an issue with escaping: if the value field contains the `;` character then it is needed to be escaped with braces as mentioned in the documentation: https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqldriverconnect-function?view=sql-server-ver15#comments

However there weren't any mention regarding embedded braces in value fields so if `key={val};ue}` then it was parsed as `key={val}`. 
The escape mechanism is not mentioned in the docs, but it seems like that doubling the ending braces (i. e. `key={value}};ue}`) is the way to go: https://github.com/mkleehammer/pyodbc/issues/569#issuecomment-496234942

This PR implements this behaviour and adds tests regarding these scenarios. 
