### PR TITLE
login.c (tds_connect): return -TDSEICONVAVAIL instead of -TDSEMEM whe…

### DIFF
--- a/src/tds/login.c
+++ b/src/tds/login.c
@@ -536,7 +536,7 @@ tds_connect(TDSSOCKET * tds, TDSLOGIN * login, int *p_oserr)
 	if (tds->conn->char_convs[client2ucs2]->to.cd == (iconv_t) -1) {
 		if (!tds_dstr_isempty(&login->client_charset)) {
 			if (TDS_FAILED(tds_iconv_open(tds->conn, tds_dstr_cstr(&login->client_charset), login->use_utf16)))
-				return -TDSEMEM;
+				return -TDSEICONVAVAIL;
 		}
 	}
 


### PR DESCRIPTION
…n tds_iconv_open fails

This makes error message more clear that character conversion is responsible for the connect failure. Fixes #486.

With this change the error message is clear that character set is athe problem:
```
freetds (invalid_charset)> /tmp/freetds/bin/tsql -H localhost -p 1433 -U sa -P sqlServerPassw0rd -D tempdb -J abracadabra
locale is "en_US.UTF-8"
locale charset is "UTF-8"
using default charset "abracadabra"
Setting tempdb as default database in login packet
Error 2401 (severity 4):
        Character set conversion is not available between client character set '%.*s' and server character set '%.*s'
There was a problem connecting to the server
```