### PR TITLE
Removing "~TDS_ODBC_ON" from connection option_flag2

### DIFF
--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -1262,7 +1262,6 @@ tdsdbopen(LOGINREC * login, const char *server, int msdblib)
 		dbclose(dbproc);
 		return NULL;
 	}
-	connection->option_flag2 &= ~TDS_ODBC_ON;	/* we're not an ODBC driver */
 	tds_fix_login(connection);		/* initialize from Environment variables */
 
 	dbproc->chkintr = NULL;


### PR DESCRIPTION
This is a change I have been using in my version of FreeTDS for a while. Recently, I've been updating our FreeTDS version to the latest FreeTDS version and am pushing this change back to the base FreeTDS.

When the following flag is set:
```c
connection->option_flag2 &= ~TDS_ODBC_ON;
```

If we have a Table-valued function with the following:
```sql
CREATE FUNCTION [dbo].[fnSomeFunction] () RETURNS @someReturnTbl TABLE (
  col_name varchar(max)
)
AS
BEGIN 
    declare @some_data_base64 varchar(max) = 'dGVzdAo=' 
    declare @some_data_bin varbinary(max) 

    set @some_data_bin = cast('' as xml).value(
            'xs:base64Binary(sql:variable("@some_data_base64"))', 
            'varbinary(max)'
        )
    RETURN
END


CREATE PROCEDURE SomeProcedure
AS
BEGIN
    declare @tmpTable table (
        col_name varchar(max)
    )
    declare @tmpName varchar(max)

    declare someCsr cursor for select col_name from fnSomeFunction()
    
    open someCsr
    fetch next from someCsr into @tmpName
    
    while @@FETCH_STATUS = 0
    begin
        insert into @tmpTable (col_name)
        values (@tmpName)
    
        fetch next from someCsr into @tmpName
    end

    close someCsr 
    deallocate someCsr 
END
GO
```

If I then try to execute `SomeProcedure` through FreeTDS, I receive the following error message:
> Error in procedure 'SomeProcedure'
> SELECT failed because the following SET options have incorrect settings: 'CONCAT_NULL_YIELDS_NULL, ANSI_WARNINGS, ANSI_PADDING'. Verify that SET options are correct for use with indexed views and/or indexes on computed columns and/or filtered indexes and/or query notifications and/or XML data type methods and/or spatial index operators.

The error message is specifcally related to this line in the function:
```sql
set @some_data_bin = cast('' as xml).value(
        'xs:base64Binary(sql:variable("@some_data_base64"))', 
        'varbinary(max)'
    )
```

After removing the `~TDS_ODBC_ON` flag being set, I'm able to execute the `SomeProcedure` stored procedure without issue.