### PR TITLE
login.c: Fix issue  connecting to  SQL 2000 with TDS 7.4 or auto.

### DIFF
--- a/src/tds/login.c
+++ b/src/tds/login.c
@@ -1375,6 +1375,11 @@ tds71_do_login(TDSSOCKET * tds, TDSLOGIN* login)
 			return TDS_FAIL;
 		if (type == 1 && len >= 1) {
 			crypt_flag = p[off];
+		} else if (type == 0 && len >= 4) {// fix sql 2000 with TDS72PLUS issue
+			tdsdump_log(TDS_DBG_INFO1, "detected server version %d.%d.%d\n", p[off],p[off+1],(p[off+2]<<8)|p[off+3]);
+			if (p[off] == 8 && IS_TDS72_PLUS(tds->conn)) {
+				tds->conn->tds_version = 0x701;
+			}
 		}
 #if ENABLE_ODBC_MARS
 		if (IS_TDS72_PLUS(tds->conn) && type == 4 && len >= 1)


### PR DESCRIPTION
When connecting to SQL 2000 with the default configuration, the program would get stuck if the password was wrong.

By looking at the TDSDUMP log, I found that the program is stuck in the following location
https://github.com/FreeTDS/freetds/blob/4cd26db6202d694fa730ffa0e42c5a8fc9110f5c/src/tds/token.c#L2118
```
	rows_affected = IS_TDS72_PLUS(tds->conn) ? tds_get_int8(tds) : tds_get_int(tds)；
```

Need to determine the version of TDS earlier, I found that tds7_pre_login returns the version number of the sql server, tried to change it and tested it successfully!

ps: My English is not good, I'm from China and I use Google Translate.