### PR TITLE
Compatible with isql/osql syntax 

### DIFF
--- a/src/tds/config.c
+++ b/src/tds/config.c
@@ -1306,10 +1306,14 @@ parse_server_name_for_port(TDSLOGIN * connection, TDSLOGIN * login, bool update_
 	/* IPv6 address can be quoted */
 	if (server[0] == '[') {
 		pSep = strstr(server, "]:");
+		if (!pSep)
+			pSep = strstr(server, "],");
 		if (pSep)
 			++pSep;
 	} else {
 		pSep = strrchr(server, ':');
+		if (!pSep) 
+			pSep = strrchr(server, ',');
 	}
 
 	if (pSep && pSep != server) {	/* yes, i found it! */


### PR DESCRIPTION
Allows using server`,`port to specify server address and port number #528

tsql -Usa -Ppassword -S127.0.0.1,2022

This change makes it easy to replace batch scripts written in isql/osql syntax by renaming tsql to isql/osql