### PR TITLE
datacopy: Increase CREATE TABLE command buffer to accommodate larger queries

### DIFF
--- a/src/apps/datacopy.c
+++ b/src/apps/datacopy.c
@@ -407,7 +407,7 @@ cleanup:
 static int
 create_target_table(char *sobjname, char *owner, char *dobjname, DBPROCESS * dbsrc, DBPROCESS * dbdest)
 {
-	char ls_command[2048];
+	char ls_command[8192];
 	int i;
 	const char *sep;
 


### PR DESCRIPTION
datacopy fails on tables with an unusually high number of columns.