### PR TITLE
Address "declared with greater visibility" warnings.

### DIFF
--- a/include/ctlib.h
+++ b/include/ctlib.h
@@ -29,6 +29,18 @@
  * Internal (not part of the exposed API) prototypes and such.
  */
 
+/* Forward declarations to fix "declared with greater visibility" warnings */
+struct _cs_dynamic;
+struct _cs_param;
+struct _csremote_proc;
+struct cs_diag_msg;
+struct cs_diag_msg_client;
+struct cs_diag_msg_svr;
+struct cs_servermsg_common1;
+struct cs_servermsg_large;
+struct cs_servermsg_small;
+union cs_servermsg_internal;
+
 #include <freetds/pushvis.h>
 
 #ifdef __cplusplus
@@ -61,7 +73,7 @@ struct cs_diag_msg_client
 	CS_CLIENTMSG clientmsg;
 };
 
-typedef struct {
+typedef struct cs_servermsg_small {
 	CS_MSGNUM msgnumber;
 	CS_INT state;
 	CS_INT severity;
@@ -77,7 +89,7 @@ typedef struct {
 	CS_INT sqlstatelen;
 } CS_SERVERMSG_SMALL;
 
-typedef struct {
+typedef struct cs_servermsg_large {
 	CS_MSGNUM msgnumber;
 	CS_INT state;
 	CS_INT severity;
@@ -93,7 +105,7 @@ typedef struct {
 	CS_INT sqlstatelen;
 } CS_SERVERMSG_LARGE;
 
-typedef struct {
+typedef struct cs_servermsg_common1 {
 	CS_MSGNUM msgnumber;
 	CS_INT state;
 	CS_INT severity;
@@ -108,7 +120,7 @@ typedef struct {
 	CS_INT sqlstatelen;
 } CS_SERVERMSG_COMMON2;
 
-typedef union
+typedef union cs_servermsg_internal
 {
 	CS_SERVERMSG_SMALL small;
 	CS_SERVERMSG_LARGE large;

--- a/include/freetds/tds.h
+++ b/include/freetds/tds.h
@@ -54,6 +54,23 @@ typedef struct tds_connection TDSCONNECTION;
 typedef struct tds_socket TDSSOCKET;
 typedef struct tds_column TDSCOLUMN;
 typedef struct tds_bcpinfo TDSBCPINFO;
+/* More, to address "declared with greater visibility" warnings. */
+struct tds5_colinfo;
+struct tds_authentication;
+struct tds_bcpcoldata;
+struct tds_capabilities;
+struct tds_capability_type;
+struct tds_column_funcs;
+struct tds_context;
+struct tds_cursor;
+struct tds_cursor_status;
+struct tds_dynamic;
+struct tds_env;
+struct tds_locale;
+struct tds_login;
+struct tds_packet;
+struct tds_poll_wakeup;
+struct tds_result_info;
 
 #include <freetds/version.h>
 #include <freetds/sysdep_private.h>

--- a/include/freetds/utils/string.h
+++ b/include/freetds/utils/string.h
@@ -22,8 +22,6 @@
 
 #include <freetds/macros.h>
 
-#include <freetds/pushvis.h>
-
 /** \addtogroup dstring
  * @{ 
  */
@@ -37,6 +35,8 @@ typedef struct tds_dstr {
 	size_t dstr_size;
 	char dstr_s[1];
 } *DSTR;
+
+#include <freetds/pushvis.h>
 
 /** Internal representation for an empty string */
 extern const struct tds_dstr tds_str_empty;


### PR DESCRIPTION
Ensure that members of types that should be unhidden have unhidden forward declarations; likewise for their members, recursively.  To that end, give CS_SERVERMSG_*'s underlying struct/union types explicit names (cs_servermsg_*).

Split from #555.