### PR TITLE
{dblib,odbc}/unittests/common.h: Allow FREETDS_SRCDIR overrides.

### DIFF
--- a/src/dblib/unittests/common.h
+++ b/src/dblib/unittests/common.h
@@ -41,7 +41,9 @@
 #define EXIT_SUCCESS 0
 #endif
 
+#ifndef FREETDS_SRCDIR
 #define FREETDS_SRCDIR FREETDS_TOPDIR "/src/dblib/unittests"
+#endif
 
 #if defined(HAVE__SNPRINTF) && !defined(HAVE_SNPRINTF)
 #define snprintf _snprintf

--- a/src/odbc/unittests/common.h
+++ b/src/odbc/unittests/common.h
@@ -41,7 +41,9 @@
 #endif
 #endif
 
+#ifndef FREETDS_SRCDIR
 #define FREETDS_SRCDIR FREETDS_TOPDIR "/src/odbc/unittests"
+#endif
 
 extern HENV odbc_env;
 extern HDBC odbc_conn;


### PR DESCRIPTION
Split from #555.