### PR TITLE
tds_setup_connection: Skip nvc/uvc check under OpenServer.

### DIFF
--- a/src/tds/login.c
+++ b/src/tds/login.c
@@ -440,7 +440,9 @@ tds_setup_connection(TDSSOCKET *tds, TDSLOGIN *login, bool set_db, bool set_spid
 		tds_quote_id(tds, strchr(str, 0), tds_dstr_cstr(&login->database), -1);
 		strcat(str, "\n");
 	}
-	if (IS_TDS50(tds->conn)) {
+	if (IS_TDS50(tds->conn)
+	    &&	(tds->conn->product_name == NULL
+		 ||  strcasecmp(tds->conn->product_name, "OpenServer") != 0)) {
 		strcat(str, "SELECT CONVERT(NVARCHAR(3), 'abc') nvc\n");
 		parse_results = true;
 		if (tds->conn->product_version >= TDS_SYB_VER(12, 0, 0))


### PR DESCRIPTION
OpenServer instances may well report "Unknown language request" for it, resulting in outright login failures.

Split from #555.