### PR TITLE
Address Windows build errors, most config-dependent.

### DIFF
--- a/src/odbc/connectparams.c
+++ b/src/odbc/connectparams.c
@@ -95,8 +95,12 @@ static FILE *tdoGetIniFileName(void);
  *    expect see tdoGetIniFileName().
  *
  */
-static int SQLGetPrivateProfileString(LPCSTR pszSection, LPCSTR pszEntry, LPCSTR pszDefault, LPSTR pRetBuffer, int nRetBuffer,
-				      LPCSTR pszFileName);
+#ifndef _WIN32
+static
+#endif
+int SQLGetPrivateProfileString(LPCSTR pszSection, LPCSTR pszEntry,
+			       LPCSTR pszDefault, LPSTR pRetBuffer,
+			       int nRetBuffer, LPCSTR pszFileName);
 #endif
 
 #if defined(FILENAME_MAX) && FILENAME_MAX < 512
@@ -556,7 +560,7 @@ odbc_build_connect_string(TDS_ERRS *errs, TDS_PARSED_PARAM *params, char **out)
 
 #if !HAVE_SQLGETPRIVATEPROFILESTRING
 
-#ifdef _WIN32
+#if defined(_WIN32)  &&  !defined(TDS_NO_DM)
 #  error There is something wrong  in configuration...
 #endif
 
@@ -584,7 +588,10 @@ tdoParseProfile(const char *option, const char *value, void *param)
 	return true;
 }
 
-static int
+#ifndef _WIN32
+static
+#endif
+int
 SQLGetPrivateProfileString(LPCSTR pszSection, LPCSTR pszEntry, LPCSTR pszDefault, LPSTR pRetBuffer, int nRetBuffer,
 			   LPCSTR pszFileName)
 {

--- a/src/odbc/unittests/connect.c
+++ b/src/odbc/unittests/connect.c
@@ -12,18 +12,25 @@ init_connect(void)
 
 #ifdef _WIN32
 #include <odbcinst.h>
+#undef SQLGetPrivateProfileString
+#if !HAVE_SQLGETPRIVATEPROFILESTRING
+#  define SQLGetPrivateProfileString tds_SQLGetPrivateProfileString
+int tds_SQLGetPrivateProfileString(LPCSTR pszSection, LPCSTR pszEntry,
+                                   LPCSTR pszDefault, LPSTR pRetBuffer,
+                                   int nRetBuffer, LPCSTR pszFileName);
+#endif
 
 static char *entry = NULL;
 
 static char *
 get_entry(const char *key)
 {
-	static TCHAR buf[256];
-
+	static char buf[256];
+ 
 	entry = NULL;
-	if (SQLGetPrivateProfileString((LPCTSTR) T(odbc_server), (LPCTSTR) T(key), TEXT(""),
-				       buf, TDS_VECTOR_SIZE(buf), TEXT("odbc.ini")) > 0)
-		entry = C(buf);
+	if (SQLGetPrivateProfileString(odbc_server, key, "", buf,
+                                       TDS_VECTOR_SIZE(buf), "odbc.ini") > 0)
+		entry = buf;
 
 	return entry;
 }

--- a/src/odbc/winlogin.c
+++ b/src/odbc/winlogin.c
@@ -173,5 +173,9 @@ LoginDlgProc(HWND hDlg, UINT message, WPARAM wParam,	/* */
 bool
 get_login_info(HWND hwndParent, TDSLOGIN * login)
 {
+#ifdef DLL_EXPORT
 	return !!DialogBoxParam(hinstFreeTDS, MAKEINTRESOURCE(IDD_LOGIN), hwndParent, (DLGPROC) LoginDlgProc, (LPARAM) login);
+#else
+	return false;
+#endif
 }

--- a/src/odbc/winsetup.c
+++ b/src/odbc/winsetup.c
@@ -318,7 +318,12 @@ ConfigDSN(HWND hwndParent, WORD fRequest, LPCSTR lpszDriver, LPCSTR lpszAttribut
 	/* Maybe allow the user to edit it */
 	if (hwndParent && fRequest != ODBC_REMOVE_DSN) {
 		INT_PTR result;
+#ifdef DLL_EXPORT
 		result = DialogBoxParam(hinstFreeTDS, MAKEINTRESOURCE(IDD_DSN), hwndParent, (DLGPROC) DSNDlgProc, (LPARAM) di);
+#else
+		result = -1;
+		SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+#endif
 		if (result < 0) {
 			DWORD errorcode = GetLastError();
 			char buf[1000];
@@ -428,6 +433,7 @@ check_installer_errors(void)
 	return SQL_SUCCEEDED(ret);
 }
 
+#ifdef DLL_EXPORT
 /**
  * Allow install using regsvr32
  */
@@ -476,4 +482,4 @@ DllUnregisterServer(void)
 		return SELFREG_E_CLASS;
 	return S_OK;
 }
-
+#endif /* DLL_EXPORT */

--- a/src/utils/unittests/challenge.c
+++ b/src/utils/unittests/challenge.c
@@ -35,6 +35,7 @@
 #endif
 
 #include "tds_sysdep_public.h"
+#include <freetds/sysdep_private.h>
 #include <freetds/utils/md4.h>
 #include <freetds/utils/md5.h>
 #include <freetds/utils/hmac_md5.h>


### PR DESCRIPTION
* In the absence of an external SQLGetPrivateProfileString, fail the build only when expecting to use an external driver manager, and expose tds_SQLGetPrivateProfileString to the odbc "connect" unit test. Don't let that test attempt to use SQLGetPrivateProfileStringW even in Unicode builds.
* src/odbc/win*.c: Accommodate static builds, with no hinstFreeTDS; in particular, never attempt to show FreeTDS dialog boxes there.
* src/utils/unittests/challenge.c: #include <freetds/sysdep_private.h>
  to ensure the availability of strcasecmp.

Split from #555.