### PR TITLE
cs_convert, dbconvert: Truncate data as needed.

### DIFF
--- a/src/ctlib/cs.c
+++ b/src/ctlib/cs.c
@@ -592,14 +592,14 @@ _cs_convert(CS_CONTEXT * ctx, const CS_DATAFMT_COMMON * srcfmt, CS_VOID * srcdat
 		case SYBBINARY:
 		case SYBVARBINARY:
 		case SYBIMAGE:
-			memcpy(dest, srcdata, src_len);
-			*resultlen = src_len;
+			memcpy(dest, srcdata, minlen);
+			*resultlen = minlen;
 
 			if (src_len > destlen) {
 				tdsdump_log(TDS_DBG_FUNC, "error: src_len > destlen\n");
 				_csclient_msg(ctx, "cs_convert", 2, 4, 1, 36, "");
-				ret = CS_FAIL;
-			} else {
+				src_len = destlen;
+			} /* else */ {
 				switch (destfmt->format) {
 				case CS_FMT_PADNULL:
 					memset(dest + src_len, '\0', destlen - src_len);
@@ -829,7 +829,6 @@ _cs_convert(CS_CONTEXT * ctx, const CS_DATAFMT_COMMON * srcfmt, CS_VOID * srcdat
 			tdsdump_log(TDS_DBG_FUNC, "Data-conversion resulted in overflow\n");
 			_csclient_msg(ctx, "cs_convert", 2, 4, 1, 36, "");
 			len = destlen;
-			ret = CS_FAIL;
 		}
 		switch (destfmt->format) {
 

--- a/src/ctlib/unittests/cs_convert.c
+++ b/src/ctlib/unittests/cs_convert.c
@@ -296,11 +296,13 @@ main(void)
 	DO_TEST(CS_INT test = 1234567;
 		CS_CHAR test2[] = "1234567", CS_INT_TYPE, &test, sizeof(test), CS_CHAR_TYPE, 7, CS_SUCCEED, test2, 7);
 	DO_TEST(CS_CHAR test[] = "abc";
-		CS_CHAR test2[] = "ab", CS_CHAR_TYPE, test, 3, CS_CHAR_TYPE, 2, CS_FAIL, test2, 2);
+		CS_CHAR test2[] = "ab", CS_CHAR_TYPE, test, 3, CS_CHAR_TYPE, 2,
+		CS_SUCCEED /* CS_FAIL */, test2, 2);
 	DO_TEST(CS_CHAR test[] = "abc";
 		CS_CHAR test2[] = "616263", CS_BINARY_TYPE, test, 3, CS_CHAR_TYPE, 6, CS_SUCCEED, test2, 6);
 	DO_TEST(CS_CHAR test[] = "abcdef";
-		CS_CHAR test2[] = "616263", CS_BINARY_TYPE, test, 6, CS_CHAR_TYPE, 6, CS_FAIL, test2, 6);
+		CS_CHAR test2[] = "616263", CS_BINARY_TYPE, test, 6,
+		CS_CHAR_TYPE, 6, CS_SUCCEED /* CS_FAIL */, test2, 6);
 
 	/* conversion to various binaries */
 	DO_TEST(CS_CHAR test[] = "616263646566";

--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -2422,10 +2422,14 @@ dbconvert_ps(DBPROCESS * dbproc, int db_srctype, const BYTE * src, DBINT srclen,
 				break;
 			default:
 				assert(destlen > 0);
-				if (destlen < 0 || srclen > destlen) {
+				if (destlen < 0) {
 					dbperror(dbproc, SYBECOFL, 0);
 					ret = -1;
 				} else {
+					if (srclen > destlen) {
+						dbperror(dbproc, 50000, 0);
+						srclen = destlen;
+					}
 					memcpy(dest, src, srclen);
 					if (srclen < destlen)
 						memset(dest + srclen, ' ', destlen - srclen);
@@ -2560,12 +2564,16 @@ dbconvert_ps(DBPROCESS * dbproc, int db_srctype, const BYTE * src, DBINT srclen,
 			break;
 		default:
 			assert(destlen > 0);
-			if (destlen < 0 || len > destlen) {
+			if (destlen < 0) {
 				dbperror(dbproc, SYBECOFL, 0);
 				ret = -1;
 				tdsdump_log(TDS_DBG_INFO1, "%d bytes type %d -> %d, destlen %d < %d required\n",
 					    srclen, srctype, desttype, destlen, len);
 				break;
+			}
+			if (len > destlen) {
+				dbperror(dbproc, 50000, 0);
+				len = destlen;
 			}
 			/* else pad with blanks */
 			memcpy(dest, dres.c, len);

--- a/src/dblib/unittests/t0019.c
+++ b/src/dblib/unittests/t0019.c
@@ -91,8 +91,10 @@ main(void)
 	TEST((SYBCHAR, "ciao\0\0", 6, SYBCHAR, -1), "len=6 63 69 61 6F 00 00 00 2A 2A 2A");
 	TEST((SYBCHAR, "ciao  ", 6, SYBCHAR, 8), "len=6 63 69 61 6F 20 20 20 20 2A 2A");
 	TEST((SYBCHAR, "ciao\0\0", 6, SYBCHAR, 8), "len=6 63 69 61 6F 00 00 20 20 2A 2A");
-	TEST((SYBCHAR, "ciao  ", 6, SYBCHAR, 4), "error");
-	TEST((SYBCHAR, "ciao\0\0", 6, SYBCHAR, 4), "error");
+	TEST((SYBCHAR, "ciao  ", 6, SYBCHAR, 4),
+	     "len=4 63 69 61 6F 2A 2A 2A 2A 2A 2A" /* "error" */);
+	TEST((SYBCHAR, "ciao\0\0", 6, SYBCHAR, 4),
+	     "len=4 63 69 61 6F 2A 2A 2A 2A 2A 2A" /* "error" */);
 	TEST((SYBCHAR, "ciao  ", 6, SYBCHAR, 6), "len=6 63 69 61 6F 20 20 2A 2A 2A 2A");
 	TEST((SYBCHAR, "ciao\0\0", 6, SYBCHAR, 6), "len=6 63 69 61 6F 00 00 2A 2A 2A 2A");
 


### PR DESCRIPTION
* Automatically truncate strings that would overflow their destinations, mainly for the sake of bulk insertions.
* Fully honor *BINARY and IMAGE data buffer size limits in cs_convert.
* Update unit tests (ctlib cs_convert, dblib t0019) accordingly.

Split from #555.