### PR TITLE
Acknowledge non-exhaustive TDS_SERVER_TYPE switch statements.

### DIFF
--- a/src/ctlib/ct.c
+++ b/src/ctlib/ct.c
@@ -2163,6 +2163,8 @@ _ct_get_client_type(const TDSCOLUMN *col, bool describe)
 	case SYBMSDATETIME2:
 	case SYBMSDATETIMEOFFSET:
 		break;
+	default: /* SYBNTEXT, etc. */
+		break;
 	}
 
 	return _cs_convert_not_client(NULL, col, NULL, NULL);

--- a/src/dblib/dbpivot.c
+++ b/src/dblib/dbpivot.c
@@ -174,6 +174,9 @@ col_equal(const struct col_t *pc1, const struct col_t *pc2)
 	case SYBMSTABLE:
 		assert( false && pc1->type );
 		break;
+
+	default:
+		return false;
 	}
 	return false;
 }
@@ -218,6 +221,9 @@ col_buffer(struct col_t *pcol)
 	case SYBMSTABLE:
 		assert( false && pcol->type );
 		break;
+
+	default:
+		return NULL;
 	}
 	return NULL;
 


### PR DESCRIPTION
Add no-op default cases to switch statements that don't explicitly cover all of TDS_SERVER_TYPE.