### PR TITLE
tds_iconv: Accommodate FreeBSD/Citrus iconv.

### DIFF
--- a/src/tds/iconv.c
+++ b/src/tds/iconv.c
@@ -657,6 +657,9 @@ tds_iconv(TDSSOCKET * tds, TDSICONV * conv, TDS_ICONV_DIRECTION io,
 
 		/* iconv success, return */
 		if (irreversible != (size_t) - 1) {
+			if (irreversible > 0) {
+				eilseq_raised = true;
+			}
 			/* here we detect end of conversion and try to reset shift state */
 			if (inbuf) {
 				/*
@@ -675,7 +678,7 @@ tds_iconv(TDSSOCKET * tds, TDSICONV * conv, TDS_ICONV_DIRECTION io,
 		if (conv_errno == EILSEQ)
 			eilseq_raised = true;
 
-		if (conv_errno != EILSEQ || io != to_client || !inbuf)
+		if (!eilseq_raised || io != to_client || !inbuf)
 			break;
 		/* 
 		 * Invalid input sequence encountered reading from server. 


### PR DESCRIPTION
Accommodate iconv implementations (such as the Citrus one used by modern FreeBSD systems) that ever indicate invalid input by reporting a positive count of irreversible characters rather than by setting errno to EILSEQ.