### PR TITLE
Fix miscellaneous one-off warnings.

### DIFF
--- a/include/freetds/odbc.h
+++ b/include/freetds/odbc.h
@@ -74,7 +74,9 @@ extern "C"
 #endif
 
 #include <freetds/pushvis.h>
-#if defined(__GNUC__) && __GNUC__ >= 4 && !defined(__MINGW32__)
+#ifdef __clang__
+#define ODBC_API SQL_API __attribute__((visibility("default")))
+#elif defined(__GNUC__) && __GNUC__ >= 4 && !defined(__MINGW32__)
 #define ODBC_API SQL_API __attribute__((externally_visible))
 #else
 #define ODBC_API SQL_API

--- a/src/ctlib/unittests/t0009.c
+++ b/src/ctlib/unittests/t0009.c
@@ -37,7 +37,7 @@ main(void)
 	CS_CHAR col3[32];
 
 	CS_INT compute_col1;
-	CS_CHAR compute_col3[32];
+	CS_CHAR compute_col3[32] = "";
 
 	unsigned rows[3] = { 0, 0, 0 };
 

--- a/src/dblib/bcp.c
+++ b/src/dblib/bcp.c
@@ -2226,7 +2226,7 @@ _bcp_get_col_data(TDSBCPINFO *bcpinfo, TDSCOLUMN *bindcol, int offset TDS_UNUSED
 
 	/* if (Max) column length specified take that into consideration. */
 
-	if (bindcol->column_bindlen >= 0) {
+	/* if (bindcol->column_bindlen >= 0) */ { /* bindlen is unsigned */
 		if (bindcol->column_bindlen == 0)
 			goto null_data;
 		if (collen)

--- a/src/odbc/unittests/rowset.c
+++ b/src/odbc/unittests/rowset.c
@@ -12,6 +12,20 @@ test_err(int n)
 	}
 }
 
+#ifdef _MSC_VER
+/* See https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170 */
+#pragma warning(push)
+#pragma warning(disable:4996)
+static SQLRETURN
+_CHKSetStmtOption(SQLUSMALLINT option, SQLULEN value, const char* res)
+{
+    return CHKSetStmtOption(option, value, res);
+#pragma warning(pop)
+}
+#undef CHKSetStmtOption
+#define CHKSetStmtOption _CHKSetStmtOption
+#endif
+
 int
 main(void)
 {

--- a/src/tds/bulk.c
+++ b/src/tds/bulk.c
@@ -704,7 +704,7 @@ tds5_bcp_add_variable_columns(TDSBCPINFO *bcpinfo, tds_bcp_get_col_data get_col_
 
 	if (ncols) {
 		TDS_UCHAR *poff = rowbuffer + row_pos;
-		unsigned int pfx_top = offsets[ncols] / 256;
+		unsigned int pfx_top = offsets[ncols] >> 8;
 
 		tdsdump_log(TDS_DBG_FUNC, "ncols=%u poff=%p [%u]\n", ncols, poff, offsets[ncols]);
 
@@ -714,7 +714,7 @@ tds5_bcp_add_variable_columns(TDSBCPINFO *bcpinfo, tds_bcp_get_col_data get_col_
 			unsigned int n_pfx = 1;
 
 			for (i = 0; i <= ncols ; ++i)
-				if ((offsets[i] / 256) < pfx_top)
+				if ((offsets[i] >> 8) < pfx_top)
 					++n_pfx;
 			*poff++ = n_pfx;
 			--pfx_top;

--- a/src/tds/gssapi.c
+++ b/src/tds/gssapi.c
@@ -62,6 +62,8 @@
 #ifdef __APPLE__
 #define KERBEROS_APPLE_DEPRECATED(x)
 #define GSSKRB_APPLE_DEPRECATED(x)
+#undef __API_DEPRECATED
+#define __API_DEPRECATED(x, y)
 #endif
 #include <gssapi/gssapi_krb5.h>
 
@@ -238,8 +240,12 @@ tds_gss_get_auth(TDSSOCKET * tds)
 	 */
 	gss_buffer_desc send_tok;
 	OM_uint32 maj_stat, min_stat;
+#ifdef __APPLE__
+#  define nt_principal *(gss_OID_desc *) GSS_KRB5_NT_PRINCIPAL_NAME
+#else
 	/* same as GSS_KRB5_NT_PRINCIPAL_NAME but do not require .so library */
 	static gss_OID_desc nt_principal = { 10, (void*) "\x2a\x86\x48\x86\xf7\x12\x01\x02\x02\x01" };
+#endif
 	const char *server_name;
 	/* Storage for getaddrinfo calls */
 	struct addrinfo *addrs = NULL;


### PR DESCRIPTION
* odbc.h: For Clang, substitute __attribute__((visibility("default"))) for __attribute__((externally_visible)), which it at least historically didn't support.
* odbc/unittests/common.h: When the ODBC 3 API is available, favor SQLSetStmtAttr over SQLSetStmtOption, which is deprecated.
* dblib/bcp.c (_bcp_get_col_data): Comment out an always-true comparison of column_bindlen (which was never signed) to zero.
* tds5_bcp_add_variable_columns: Explicitly mark 256 as unsigned to avoid spurious signed-vs.-unsigned comparison warnings.
* gssapi.c: On macOS, additionally suppress __API_DEPRECATED right before including gssapi_krb5.h (which is at least the last explicitly included system header).
* tls.c: Define _WIN32_WINNT ahead of config.h, which might otherwise supply a somewhat different definition, yielding a warning.
* ctlib/unittests/t0009.c: Pre-zero compute_col3.  Optimized builds with Clang or LLVM-based ICC can otherwise yield a Valgrind warning concerning a strcmp call that reads slightly past the trailing NUL.