### PR TITLE
Regroup pointer comparisons to avoid subtraction.

### DIFF
--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -3168,7 +3168,7 @@ odbc_unquote(char *buf, size_t buf_len, const char *start, const char *end)
 	/* not quoted */
 	if (*start != '[' && *start != '\"') {
 		--buf_len;
-		if (end - start < buf_len)
+		if (end < start + buf_len)
 			buf_len = end - start;
 		memcpy(buf, start, buf_len);
 		buf[buf_len] = 0;
@@ -7532,7 +7532,7 @@ odbc_stat_execute(TDS_STMT * stmt _WIDE, const char *begin, int nparams, ...)
 	strcpy(p, begin);
 	p += strlen(begin);
 	tds_dstr_setlen(&stmt->query, p - proc);
-	assert(p - proc + 1 <= len);
+	assert(p + 1 <= proc + len);
 
 	/* execute it */
 	retcode = _SQLExecute(stmt);

--- a/src/odbc/odbc_util.c
+++ b/src/odbc/odbc_util.c
@@ -128,7 +128,7 @@ odbc_iso2utf(DSTR *res, const char *s, unsigned int len)
 			*p++ = u;
 		}
 	}
-	assert(p+1-out <= o_len);
+	assert(p + 1 <= out + o_len);
 	return tds_dstr_setlen(res, p - out);
 }
 
@@ -211,7 +211,7 @@ odbc_wide2utf(DSTR *res, const SQLWCHAR *s, unsigned int len)
 		}
 		*p++ = 0x80 | (0x3f & u);
 	}
-	assert(p+1-out <= o_len);
+	assert(p + 1 <= out + o_len);
 	return tds_dstr_setlen(res, p - out);
 }
 

--- a/src/tds/unittests/freeze.c
+++ b/src/tds/unittests/freeze.c
@@ -128,7 +128,7 @@ strip_headers(buffer *buf)
 			assert(end - p >= 8); /* to read SMP part */
 			len = TDS_GET_UA4LE(p+4);
 			assert(len >= 16);
-			assert(end - p >= len);
+			assert(p + len <= end);
 			p += 16;
 			len -= 16;
 			assert(end - p >= 4); /* to read TDS header part */
@@ -138,7 +138,7 @@ strip_headers(buffer *buf)
 			len = TDS_GET_UA2BE(p+2);
 		}
 		assert(len > 8);
-		assert(end - p >= len);
+		assert(p + len <= end);
 		final = p[1];
 		memmove(dst, p + 8, len - 8);
 		dst += len - 8;


### PR DESCRIPTION
The compiler always insists on treating the difference between two pointers as potentially negative, yielding warnings when comparing it to an integer that has (or will soon have) a pointer-width unsigned type. Equivalent pointer-to-pointer comparisons yield no such warnings and are still clear.

Split from #555.