### PR TITLE
read.c (tds_get_n): Avoid potential hangs on short replies.

### DIFF
--- a/src/tds/read.c
+++ b/src/tds/read.c
@@ -240,8 +240,12 @@ tds_get_n(TDSSOCKET * tds, void *dest, size_t need)
 			dest = (char *) dest + have;
 		}
 		need -= have;
-		if (TDS_UNLIKELY(tds_read_packet(tds) < 0))
+		if (TDS_UNLIKELY(tds->recv_packet->capacity < 2
+				 ||  tds->in_buf[1] != 0
+				 ||  tds_read_packet(tds) < 0)) {
+			tds_close_socket(tds); /* evidently out of sync */
 			return false;
+		}
 	}
 	if (need > 0) {
 		/* get the remainder if there is any */


### PR DESCRIPTION
Don't bother trying to receive data following a packet marked as last; rather, bail if still short.  Whenever bailing, close the socket on the way out to contain the damage from having fallen out of sync.

Split from #555.