### PR TITLE
tds_check_column_extra: Skip size check for BLOBs.

### DIFF
--- a/src/tds/tds_checks.c
+++ b/src/tds/tds_checks.c
@@ -235,7 +235,15 @@ tds_check_column_extra(const TDSCOLUMN * column)
 	assert(varint_ok);
 
 	assert(!is_numeric_type(column->column_type));
-	assert(column->column_cur_size <= column->column_size);
+	if (!is_blob_type(column->column_type)) {
+		/*
+		 * Skip for BLOBs, whose reported maximum may have
+		 * been merely nominal, and doesn't really matter
+		 * because their storage is generally allocated
+		 * separately, based on actual result sizes.
+		 */
+		assert(column->column_cur_size <= column->column_size);
+	}
 
 	/* check size of fixed type correct */
 	size = tds_get_size_by_type(column->column_type);


### PR DESCRIPTION
Let column_size exceed column_cur_size for BLOBs, whose reported maximum may have been merely nominal, and doesn't really matter because their storage is generally allocated separately, based on actual result sizes.

Split from #555.