### PR TITLE
tds_select: Treat EAGAIN and EINPROGRESS like EINTR.

### DIFF
--- a/src/tds/net.c
+++ b/src/tds/net.c
@@ -671,6 +671,8 @@ tds_select(TDSSOCKET * tds, unsigned tds_sel, int timeout_seconds)
 
 			switch (sock_errno) {
 			case TDSSOCK_EINTR:
+			case EAGAIN:
+			case TDSSOCK_EINPROGRESS:
 				/* FIXME this should be global maximun, not loop one */
 				seconds += poll_seconds;
 				break;	/* let interrupt handler be called */
@@ -683,7 +685,10 @@ tds_select(TDSSOCKET * tds, unsigned tds_sel, int timeout_seconds)
 			}
 		}
 
-		assert(rc == 0 || (rc < 0 && sock_errno == TDSSOCK_EINTR));
+		assert(rc == 0 || (rc < 0 && (sock_errno == TDSSOCK_EINTR ||
+					      sock_errno == EAGAIN ||
+					      sock_errno == TDSSOCK_EINPROGRESS
+					      )));
 
 		if (tds_get_ctx(tds) && tds_get_ctx(tds)->int_handler) {	/* interrupt handler installed */
 			/*


### PR DESCRIPTION
Call the registered interrupt handler (if any) for all three.

Split from #555.