### PR TITLE
tds_fix_column_size: Allow full size for output columns.

### DIFF
--- a/src/tds/query.c
+++ b/src/tds/query.c
@@ -1554,10 +1554,14 @@ tds_fix_column_size(TDSSOCKET * tds TDS_UNUSED, TDSCOLUMN * curcol)
 		break;
 	case 2:
 		/* note that varchar(max)/varbinary(max) have a varint of 8 */
-		if (curcol->on_server.column_type == XSYBNVARCHAR || curcol->on_server.column_type == XSYBNCHAR)
+		if (size == 0  &&  curcol->column_output) {
+			min = 8000;
+		} else if (curcol->on_server.column_type == XSYBNVARCHAR
+			   || curcol->on_server.column_type == XSYBNCHAR) {
 			min = 2;
-		else
+		} else {
 			min = 1;
+		}
 		size = MAX(MIN(size, 8000u), min);
 		break;
 	case 4:


### PR DESCRIPTION
If an output column of type VARCHAR(n) or the like has no current size, send the type's maximum size; otherwise, the server will fill in only the first character/byte.

Split from #555.