### PR TITLE
_cs_convert: Cap binary/image copying to the destination length.

### DIFF
--- a/src/ctlib/cs.c
+++ b/src/ctlib/cs.c
@@ -592,8 +592,8 @@ _cs_convert(CS_CONTEXT * ctx, const CS_DATAFMT_COMMON * srcfmt, CS_VOID * srcdat
 		case SYBBINARY:
 		case SYBVARBINARY:
 		case SYBIMAGE:
-			memcpy(dest, srcdata, src_len);
-			*resultlen = src_len;
+			memcpy(dest, srcdata, minlen);
+			*resultlen = minlen;
 
 			if (src_len > destlen) {
 				tdsdump_log(TDS_DBG_FUNC, "error: src_len > destlen\n");


### PR DESCRIPTION
Excessively long input already yielded an error, but would previously overrun the destination buffer along the way.