### PR TITLE
Inform CMake of some accidentally Autotools-only tests.

### DIFF
--- a/src/ctlib/unittests/CMakeLists.txt
+++ b/src/ctlib/unittests/CMakeLists.txt
@@ -8,7 +8,7 @@ foreach(target t0001 t0002 t0003 t0004
 	ct_diagclient ct_diagserver ct_diagall
 	cs_config cancel blk_in
 	blk_out ct_cursor ct_cursors
-	ct_dynamic blk_in2 datafmt data
+	ct_dynamic blk_in2 data datafmt rpc_fail row_count
 	all_types long_binary will_convert
 	variant errors ct_command)
 	add_executable(c_${target} EXCLUDE_FROM_ALL ${target}.c)

--- a/src/tds/unittests/CMakeLists.txt
+++ b/src/tds/unittests/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(t_common STATIC common.c common.h utf8.c allcolumns.c)
 
 foreach(target t0001 t0002 t0003 t0004 t0005 t0006 t0007 t0008 dynamic1
     convert dataread utf8_1 utf8_2 utf8_3 numeric iconv_fread toodynamic
-    readconf collations corrupt declarations portconf
+    readconf charconv nulls collations corrupt declarations portconf
     parsing freeze strftime log_elision convert_bounds tls)
 	add_executable(t_${target} EXCLUDE_FROM_ALL ${target}.c)
 	set_target_properties(t_${target} PROPERTIES OUTPUT_NAME ${target})


### PR DESCRIPTION
Add rpc_fail and row_count for ctlib and charconv and nulls for tds. Along the way, formally swap the order of ctlib's data and datafmt tests to match Makefile.am and facilitate future comparison.

(Addresses discrepancies observed while reworking #560.)