### PR TITLE
tds_lookup_host: Fall back on unsupported address families.

### DIFF
--- a/src/tds/config.c
+++ b/src/tds/config.c
@@ -1013,6 +1013,18 @@ tds_lookup_host(const char *servername)	/* (I) name of the server               
 
 #ifdef AI_ADDRCONFIG
 	hints.ai_flags |= AI_ADDRCONFIG;
+	switch (getaddrinfo(servername, NULL, &hints, &addr)) {
+	case 0:
+		return addr;
+	case EAI_FAMILY:
+#  ifdef EAI_ADDRFAMILY
+	case EAI_ADDRFAMILY:
+#  endif
+		hints.ai_flags &= ~AI_ADDRCONFIG;
+		break;
+	default:
+		return NULL;
+	}
 #endif
 
 	if (getaddrinfo(servername, NULL, &hints, &addr))


### PR DESCRIPTION
If getaddrinfo with AI_ADDRCONFIG enabled fails with an error pointing to that flag (EAI_FAMILY or, if defined, EAI_ADDRFAMILY), try again without it rather than immediately bailing.  The result will be useful only in corner cases (IPv6 loopback addresses on otherwise IPv4-only hosts or vice versa), but the portconf unit test otherwise fails on IPv4-only or IPv6-only hosts supporting AI_ADDRCONFIG.