### PR TITLE
freedts:server: login: fixed incorrect error handling

### DIFF
--- a/src/server/login.c
+++ b/src/server/login.c
@@ -115,6 +115,7 @@ tds_listen(TDSCONTEXT * ctx, int ip_port)
 	CLOSESOCKET(s);
 	tds = tds_alloc_socket(ctx, 4096);
 	if (!tds) {
+		close(fd);
 		fprintf(stderr, "out of memory");
 		return NULL;
 	}


### PR DESCRIPTION
Found by Postgres Professional with ISP RAS Svace
Signed-off-by: Maksim Korotkov <m.korotkov@postgrespro.ru>