### PR TITLE
ct: fixed logic operator precedence

### DIFF
--- a/src/ctlib/ct.c
+++ b/src/ctlib/ct.c
@@ -1954,7 +1954,7 @@ _ct_bind_data(CS_CONTEXT *ctx, TDSRESULTINFO * resinfo, TDSRESULTINFO *bindinfo,
 		destfmt.format = bindcol->column_bindfmt;
 
 		/* if convert return FAIL mark error but process other columns */
-		if ((ret = _cs_convert(ctx, &srcfmt, src, &destfmt, dest, pdatalen) != CS_SUCCEED)) {
+		if ((ret = _cs_convert(ctx, &srcfmt, src, &destfmt, dest, pdatalen)) != CS_SUCCEED) {
 			tdsdump_log(TDS_DBG_FUNC, "cs_convert-result = %d\n", ret);
 			result = 1;
 			tdsdump_log(TDS_DBG_INFO1, "error: converted only %d bytes for type %d \n",


### PR DESCRIPTION
Possible wrong assignment due to logic ops precedence. Changed by analogy to src/ctlib/blk.c

Found by Postgres Professional with ISP RAS Svace