### PR TITLE
pool: avoided potential NULL dereference

### DIFF
--- a/src/pool/user.c
+++ b/src/pool/user.c
@@ -307,6 +307,10 @@ pool_user_login(TDS_POOL * pool, TDS_POOL_USER * puser)
 	}
 
 	puser->login = login = tds_alloc_login(true);
+	if (!login) {
+		fprintf(stderr, "tds_alloc_login() failed.\n");
+		return false;
+	}
 	if (tds->in_flag == TDS_LOGIN) {
 		if (!tds->conn->tds_version)
 			tds->conn->tds_version = 0x500;


### PR DESCRIPTION
The result of tds_alloc_login() is usually checked against NULL before use.

Found by Postgres Professional with ISP RAS Svace