### PR TITLE
defncopy: avoid potential null dereference

### DIFF
--- a/src/apps/defncopy.c
+++ b/src/apps/defncopy.c
@@ -980,6 +980,10 @@ get_login(int argc, char *argv[], OPTIONS *options)
 			break;
 		case 'P':
 			password = tds_getpassarg(optarg);
+			if (!password) {
+				fprintf(stderr, "Error getting password\n");
+				exit(1);
+			}
 			DBSETLPWD(login, password);
 			memset(password, 0, strlen(password));
 			free(password);


### PR DESCRIPTION
The tds_getpassarg() function may return a NULL value, which must be carefully checked before it is used.

Found by Postgres Professional with ISPRAS Svace
Signed-off-by: Maksim Korotkov <m.korotkov@postgrespro.ru>