### PR TITLE
avoid version for odbc driver

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -666,6 +666,11 @@ AM_CONDITIONAL(INCODBC, test "$build_odbc" = "yes")
 if test "$build_odbc" = "yes"
 then
 	case $host_os in
+	linux*)
+		if test "$with_odbc_nodm" = ""; then
+			FREETDS_ODBC_MODULE="-avoid-version"
+		fi
+		;;
 	darwin* | rhapsody*)
 		if test "$with_odbc_nodm" = ""; then
 			FREETDS_ODBC_MODULE="-module"

--- a/freetds.spec.in
+++ b/freetds.spec.in
@@ -78,12 +78,12 @@ find "$RPM_BUILD_ROOT" -name "*.la" -delete
 %post unixodbc
 echo "[FreeTDS]
 Description = FreeTDS unixODBC Driver
-Driver = %{_libdir}/libtdsodbc.so.0
-Setup = %{_libdir}/libtdsodbc.so.0" | odbcinst -i -d -r > /dev/null 2>&1 || true
+Driver = %{_libdir}/libtdsodbc.so
+Setup = %{_libdir}/libtdsodbc.so" | odbcinst -i -d -r > /dev/null 2>&1 || true
 echo "[SQL Server]
 Description = FreeTDS unixODBC Driver
-Driver = %{_libdir}/libtdsodbc.so.0
-Setup = %{_libdir}/libtdsodbc.so.0" | odbcinst -i -d -r > /dev/null 2>&1 || true
+Driver = %{_libdir}/libtdsodbc.so
+Setup = %{_libdir}/libtdsodbc.so" | odbcinst -i -d -r > /dev/null 2>&1 || true
 
 %preun unixodbc
 odbcinst -u -d -n 'FreeTDS' > /dev/null 2>&1 || true
@@ -109,7 +109,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files unixodbc
 %defattr(-,root,root)
-%{_libdir}/libtdsodbc.so*
+%{_libdir}/libtdsodbc.so
 
 %files doc
 %defattr (-,root,root)


### PR DESCRIPTION
Currently, freetds produces `libtdsodbc.so.0.0`, creates `libtdsodbc.so.0` and `libtdsodbc.so` symlinks toward it when building with autotools. But in fact, those files are not required, and this library does not need to be versioned.

So, it might be better removing version from `libtdsodbc.so`, the same as what was did when building with cmake.