### PR TITLE
Use "TDS server" instead of "Adaptive Server" in error messages

### DIFF
--- a/doc/dblib_errors.txt
+++ b/doc/dblib_errors.txt
@@ -156,7 +156,7 @@ SYBECLPR	EXCONVERSION	Data conversion resulted in loss of precision.
 SYBECNOR	EXPROGRAM	Column number out of range.
 SYBECNOV	EXCONVERSION	Attempt to set variable to NULL resulted in overflow.
 SYBECOFL	EXCONVERSION	Data conversion resulted in overflow.
-SYBECONN	EXCOMM	Unable to connect: Adaptive Server is unavailable or does not exist.
+SYBECONN	EXCOMM	Unable to connect: TDS server is unavailable or does not exist.
 SYBECRNC	EXPROGRAM	The current row is not a result of compute clause %1!, so it is illegal to attempt to extract that data from this row.
 SYBECRSAGR	EXPROGRAM	Aggregate functions are not allowed in a cursor statement.
 SYBECRSBROL	EXPROGRAM	Backward scrolling cannot be used in a forward scrolling cursor.
@@ -207,17 +207,17 @@ SYBEETD	EXPROGRAM	Failure to send the expected amount of TEXT or IMAGE data via 
 SYBEEUNR	EXCOMM	Unsolicited event notification received.
 SYBEEVOP	EXINFO	Called dbregwatch with a bad options parameter.
 SYBEEVST	EXINFO	Must initiate a transaction before calling dbregparam.
-SYBEFCON	EXCOMM	Adaptive Server connection failed.
+SYBEFCON	EXCOMM	TDS server connection failed.
 SYBEFRES	EXFATAL	Challenge-Response function failed.
 SYBEFSHD	EXRESOURCE	Error in attempting to find the Sybase home directory.
 SYBEFUNC	EXPROGRAM	Functionality not supported at the specified version level.
 SYBEICN	EXPROGRAM	Invalid computeid or compute column number.
-SYBEIDCL	EXCONSISTENCY	Illegal datetime column length returned by Adaptive Server. Legal datetime lengths are 4 and 8 bytes.
+SYBEIDCL	EXCONSISTENCY	Illegal datetime column length returned by TDS server. Legal datetime lengths are 4 and 8 bytes.
 SYBEIDECCL	EXCONSISTENCY	Invalid decimal column length returned by the server.
-SYBEIFCL	EXCONSISTENCY	Illegal floating-point column length returned by Adaptive Server. Legal floating-point lengths are 4 and 8 bytes.
+SYBEIFCL	EXCONSISTENCY	Illegal floating-point column length returned by TDS server. Legal floating-point lengths are 4 and 8 bytes.
 SYBEIFNB	EXPROGRAM	Illegal field number passed to bcp_control.
-SYBEIICL	EXCONSISTENCY	Illegal integer column length returned by Adaptive Server. Legal integer lengths are 1, 2, and 4 bytes.
-SYBEIMCL	EXCONSISTENCY	Illegal money column length returned by Adaptive Server. Legal money lengths are 4 and 8 bytes. 396
+SYBEIICL	EXCONSISTENCY	Illegal integer column length returned by TDS server. Legal integer lengths are 1, 2, and 4 bytes.
+SYBEIMCL	EXCONSISTENCY	Illegal money column length returned by TDS server. Legal money lengths are 4 and 8 bytes. 396
 SYBEINLN	EXUSER	Interface file: unexpected end-of-line.
 SYBEINTF	EXUSER	Server name not found in interface file.
 SYBEINUMCL	EXCONSISTENCY	Invalid numeric column length returned by the server.
@@ -264,7 +264,7 @@ SYBERESP	EXPROGRAM	Response function address passed to dbresponse must be non-NU
 SYBERPCS	EXINFO	Must call dbrpcinit before dbrpcparam or dbrpcsend.
 SYBERPIL	EXPROGRAM	It is illegal to pass -1 to dbrpcparam for the datalen of parameters which are of type SYBCHAR, SYBVARCHAR, SYBBINARY, or SYBVARBINARY.
 SYBERPNA	EXNONFATAL	The RPC facility is available only when using a server whose version number is 4.0 or later.
-SYBERPND	EXPROGRAM	Attempt to initiate a new Adaptive Server operation with results pending.
+SYBERPND	EXPROGRAM	Attempt to initiate a new TDS server operation with results pending.
 SYBERPNULL	EXPROGRAM	value parameter for dbrpcparam can be NULL, only if the datalen parameter is 0.
 SYBERPTXTIM	EXPROGRAM	RPC parameters cannot be of type text or image.
 SYBERPUL	EXPROGRAM	When passing a SYBINTN, SYBDATETIMN, SYBMONEYN, or SYBFLTN parameter via dbrpcparam, it is necessary to specify the parameter's maximum or actual length so that DB-Library can recognize it as a SYINT1, SYBINT2, SYBINT4, SYBMONEY, SYBMONEY4, and so on.
@@ -275,12 +275,12 @@ SYBESECURE	EXPROGRAM	Secure SQL Server function not supported in this version.
 SYBESEFA	EXPROGRAM	DBSETNOTIFS cannot be called if connections are present.
 SYBESEOF	EXCOMM	Unexpected EOF from the server.
 SYBESFOV	EXPROGRAM	International Release: dbsafestr overflowed its destination buffer.
-SYBESMSG	EXSERVER	General Adaptive Server error: Check messages from the server.
+SYBESMSG	EXSERVER	General TDS server error: Check messages from the server.
 SYBESOCK	EXCOMM	Unable to open socket.
 SYBESPID	EXPROGRAM	Called dbspid with a NULL dbproc.
-SYBESYNC	EXCOMM	Read attempted while out of synchronization with Adaptive Server.
+SYBESYNC	EXCOMM	Read attempted while out of synchronization with TDS server.
 SYBETEXS	EXINFO	Called dbmoretext with a bad size parameter.
-SYBETIME	EXTIME	Adaptive Server connection timed out.
+SYBETIME	EXTIME	TDS server connection timed out.
 SYBETMCF	EXPROGRAM	Attempt to install too many custom formats via dbfmtinstall.
 SYBETMTD	EXPROGRAM	Attempt to send too much TEXT data via the dbmoretext call.
 SYBETPAR	EXPROGRAM	No SYBTEXT or SYBIMAGE parameters were defined.

--- a/doc/htdoc/mars.html
+++ b/doc/htdoc/mars.html
@@ -65,7 +65,7 @@ it's a compatibility feature.  </p>
 	<li>update table B</li>
 </ol>
 
-using a single connection to the server.  An attempt to use one connection in this way results in the dread 20019 error: &ldquo;Attempt to initiate a new Adaptive Server operation with results pending&rdquo;.  </p>
+using a single connection to the server.  An attempt to use one connection in this way results in the dread 20019 error: &ldquo;Attempt to initiate a new TDS server operation with results pending&rdquo;.  </p>
 
 <p>  To implement the above, a TDS client uses two connections: one for selecting, the other for updating.  </p>
 

--- a/doc/userguide.xml
+++ b/doc/userguide.xml
@@ -1711,7 +1711,7 @@ The server responds with a port number.
 	<prompt>$ </prompt><userinput>tsql -S <replaceable>emforester</replaceable> -U <replaceable>sa</replaceable>   #only connect?</userinput>
 	<prompt>Password: </prompt>
 	<computeroutput>Msg 20009, Level 9, State -1, Server OpenClient, Line -1
-	Unable to connect: Adaptive Server is unavailable or does not exist
+	Unable to connect: TDS server is unavailable or does not exist
 	There was a problem connecting to the server</computeroutput></screen>
 	</example>
 	If you get message 20009, remember you haven't connected to the machine.  It's a configuration or network issue,  <emphasis>not a protocol failure</emphasis>.  Verify the server is up, has the name and IP address &freetds; is using, and is listening to the configured port.</para>
@@ -1744,7 +1744,7 @@ The server responds with a port number.
 	<computeroutput>Msg 20017, Level 9, State -1, Server OpenClient, Line -1
 	Unexpected EOF from the server
 	Msg 20002, Level 9, State -1, Server OpenClient, Line -1
-	Adaptive Server connection failed
+	TDS server connection failed
 	There was a problem connecting to the server</computeroutput></screen>
 	</example>
 	
@@ -1761,7 +1761,7 @@ The server responds with a port number.
 	<computeroutput>Msg 18456, Level 14, State 1, Server [<replaceable>servername</replaceable>], Line 0
 	Login failed for user 'notme'.
 	Msg 20002, Level 9, State -1, Server OpenClient, Line -1
-	Adaptive Server connection failed
+	TDS server connection failed
 	There was a problem connecting to the server</computeroutput></screen>
 	</example></para>
 	

--- a/include/freetds/tds.h
+++ b/include/freetds/tds.h
@@ -1759,9 +1759,9 @@ tds_capability_enabled(const TDS_CAPABILITY_TYPE *cap, unsigned cap_num)
 
 #define IS_TDSDEAD(x) (((x) == NULL) || (x)->state == TDS_DEAD)
 
-/** Check if product is Sybase (such as Adaptive Server Enterrprice). x should be a TDSSOCKET*. */
+/** Check if product is Sybase (such as Adaptive Server Enterprise). x should be a TDSSOCKET*. */
 #define TDS_IS_SYBASE(x) (!((x)->conn->product_version & 0x80000000u))
-/** Check if product is Microsft SQL Server. x should be a TDSSOCKET*. */
+/** Check if product is Microsoft SQL Server. x should be a TDSSOCKET*. */
 #define TDS_IS_MSSQL(x) (((x)->conn->product_version & 0x80000000u)!=0)
 
 /** Calc a version number for mssql. Use with TDS_MS_VER(7,0,842).

--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -7917,7 +7917,7 @@ static const DBLIB_ERROR_MESSAGE dblib_error_messages[] =
 	, { SYBECNOR,           EXPROGRAM,	"Column number out of range\0" }
 	, { SYBECNOV,        EXCONVERSION,	"Attempt to set variable to NULL resulted in overflow\0" }
 	, { SYBECOFL,        EXCONVERSION,	"Data conversion resulted in overflow\0" }
-	, { SYBECONN,              EXCOMM,	"Unable to connect: Adaptive Server is unavailable or does not exist\0" }
+	, { SYBECONN,              EXCOMM,	"Unable to connect: TDS server is unavailable or does not exist\0" }
 	, { SYBECRNC,           EXPROGRAM,	"The current row is not a result of compute clause %1!, so it is illegal to attempt "
 						"to extract that data from this row\0%d" }
 	, { SYBECRSAGR,         EXPROGRAM,	"Aggregate functions are not allowed in a cursor statement\0" }
@@ -7975,20 +7975,20 @@ static const DBLIB_ERROR_MESSAGE dblib_error_messages[] =
 	, { SYBEEUNR,              EXCOMM,	"Unsolicited event notification received\0" }
 	, { SYBEEVOP,              EXINFO,	"Called dbregwatch with a bad options parameter\0" }
 	, { SYBEEVST,              EXINFO,	"Must initiate a transaction before calling dbregparam\0" }
-	, { SYBEFCON,              EXCOMM,	"Adaptive Server connection failed\0" }
+	, { SYBEFCON,              EXCOMM,	"TDS server connection failed\0" }
 	, { SYBEFRES,             EXFATAL,	"Challenge-Response function failed\0" }
 	, { SYBEFSHD,          EXRESOURCE,	"Error in attempting to find the Sybase home directory\0" }
 	, { SYBEFUNC,           EXPROGRAM,	"Functionality not supported at the specified version level\0" }
 	, { SYBEICN,            EXPROGRAM,	"Invalid computeid or compute column number\0" }
-	, { SYBEIDCL,       EXCONSISTENCY,	"Illegal datetime column length returned by Adaptive Server. Legal datetime lengths "
+	, { SYBEIDCL,       EXCONSISTENCY,	"Illegal datetime column length returned by TDS server. Legal datetime lengths "
 						"are 4 and 8 bytes\0" }
 	, { SYBEIDECCL,     EXCONSISTENCY,	"Invalid decimal column length returned by the server\0" }
-	, { SYBEIFCL,       EXCONSISTENCY,	"Illegal floating-point column length returned by Adaptive Server. Legal "
+	, { SYBEIFCL,       EXCONSISTENCY,	"Illegal floating-point column length returned by TDS server. Legal "
 						"floating-point lengths are 4 and 8 bytes\0" }
 	, { SYBEIFNB,           EXPROGRAM,	"Illegal field number passed to bcp_control\0" }
-	, { SYBEIICL,       EXCONSISTENCY,	"Illegal integer column length returned by Adaptive Server. Legal integer lengths "
+	, { SYBEIICL,       EXCONSISTENCY,	"Illegal integer column length returned by TDS server. Legal integer lengths "
 						"are 1, 2, and 4 bytes\0" }
-	, { SYBEIMCL,       EXCONSISTENCY,	"Illegal money column length returned by Adaptive Server. Legal money lengths are 4 "
+	, { SYBEIMCL,       EXCONSISTENCY,	"Illegal money column length returned by TDS server. Legal money lengths are 4 "
 						"and 8 bytes\0" }
 	, { SYBEINLN,              EXUSER,	"Interface file: unexpected end-of-line\0" }
 	, { SYBEINTF,              EXUSER,	"Server name not found in configuration files\0" }
@@ -8040,7 +8040,7 @@ static const DBLIB_ERROR_MESSAGE dblib_error_messages[] =
 						"type SYBCHAR, SYBVARCHAR, SYBBINARY, or SYBVARBINARY\0" }
 	, { SYBERPNA,          EXNONFATAL,	"The RPC facility is available only when using a server whose version number is 4.0 "
 						"or later\0" }
-	, { SYBERPND,           EXPROGRAM,	"Attempt to initiate a new Adaptive Server operation with results pending\0" }
+	, { SYBERPND,           EXPROGRAM,	"Attempt to initiate a new TDS server operation with results pending\0" }
 	, { SYBERPNULL,         EXPROGRAM,	"value parameter for dbrpcparam can be NULL, only if the datalen parameter is 0\0" }
 	, { SYBERPTXTIM,        EXPROGRAM,	"RPC parameters cannot be of type text or image\0" }
 	, { SYBERPUL,           EXPROGRAM,	"When passing a SYBINTN, SYBDATETIMN, SYBMONEYN, or SYBFLTN parameter via "
@@ -8056,12 +8056,12 @@ static const DBLIB_ERROR_MESSAGE dblib_error_messages[] =
 	, { SYBESEFA,           EXPROGRAM,	"DBSETNOTIFS cannot be called if connections are present\0" }
 	, { SYBESEOF,              EXCOMM,	"Unexpected EOF from the server\0" }
 	, { SYBESFOV,           EXPROGRAM,	"International Release: dbsafestr overflowed its destination buffer\0" }
-	, { SYBESMSG,            EXSERVER,	"General Adaptive Server error: Check messages from the server\0" }
+	, { SYBESMSG,            EXSERVER,	"General TDS server error: Check messages from the server\0" }
 	, { SYBESOCK,              EXCOMM,	"Unable to open socket\0" }
 	, { SYBESPID,           EXPROGRAM,	"Called dbspid with a NULL dbproc\0" }
-	, { SYBESYNC,              EXCOMM,	"Read attempted while out of synchronization with Adaptive Server\0" }
+	, { SYBESYNC,              EXCOMM,	"Read attempted while out of synchronization with TDS server\0" }
 	, { SYBETEXS,              EXINFO,	"Called dbmoretext with a bad size parameter\0" }
-	, { SYBETIME,              EXTIME,	"Adaptive Server connection timed out\0" }
+	, { SYBETIME,              EXTIME,	"TDS server connection timed out\0" }
 	, { SYBETMCF,           EXPROGRAM,	"Attempt to install too many custom formats via dbfmtinstall\0" }
 	, { SYBETMTD,           EXPROGRAM,	"Attempt to send too much TEXT data via the dbmoretext call\0" }
 	, { SYBETPAR,           EXPROGRAM,	"No SYBTEXT or SYBIMAGE parameters were defined\0" }

--- a/src/tds/login.c
+++ b/src/tds/login.c
@@ -694,7 +694,7 @@ reroute:
 	if (TDS_FAILED(erc) || TDS_FAILED(tds_process_login_tokens(tds))) {
 		tdsdump_log(TDS_DBG_ERROR, "login packet %s\n", TDS_SUCCEED(erc)? "accepted":"rejected");
 		tds_close_socket(tds);
-		tdserror(tds_get_ctx(tds), tds, TDSEFCON, 0); 	/* "Adaptive Server connection failed" */
+		tdserror(tds_get_ctx(tds), tds, TDSEFCON, 0); 	/* "TDS server connection failed" */
 		return -TDSEFCON;
 	}
 

--- a/src/tds/util.c
+++ b/src/tds/util.c
@@ -250,22 +250,22 @@ static const TDS_ERROR_MESSAGE tds_error_messages[] =
 						"Unconverted bytes were changed to question marks ('?')" }
 	, { TDSEICONV2BIG,   EXCONVERSION,	"Some character(s) could not be converted into client's character set" }
 	, { TDSEPORTINSTANCE,      EXUSER,      "Both port and instance specified" }
-	, { TDSERPND,           EXPROGRAM,	"Attempt to initiate a new Adaptive Server operation with results pending" }
+	, { TDSERPND,           EXPROGRAM,	"Attempt to initiate a new TDS server operation with results pending" }
 	, { TDSEBTOK,              EXCOMM,	"Bad token from the server: Datastream processing out of sync" }
 	, { TDSECAP,               EXCOMM,	"DB-Library capabilities not accepted by the Server" }
 	, { TDSECAPTYP,            EXCOMM,	"Unexpected capability type in CAPABILITY datastream" }
 	, { TDSECLOS,              EXCOMM,	"Error in closing network connection" }
-	, { TDSECONN,              EXCOMM,	"Unable to connect: Adaptive Server is unavailable or does not exist" }
+	, { TDSECONN,              EXCOMM,	"Unable to connect: TDS server is unavailable or does not exist" }
 	, { TDSEEUNR,              EXCOMM,	"Unsolicited event notification received" }
-	, { TDSEFCON,              EXCOMM,	"Adaptive Server connection failed" }
+	, { TDSEFCON,              EXCOMM,	"TDS server connection failed" }
 	, { TDSENEG,               EXCOMM,	"Negotiated login attempt failed" }
 	, { TDSEOOB,               EXCOMM,	"Error in sending out-of-band data to the server" }
 	, { TDSEREAD,              EXCOMM,	"Read from the server failed" }
-	, { TDSETIME,              EXTIME,	"Adaptive Server connection timed out" }
+	, { TDSETIME,              EXTIME,	"TDS server connection timed out" }
 	, { TDSESEOF,              EXCOMM,	"Unexpected EOF from the server" }
 	, { TDSEINTF,          	   EXUSER,	"Server name not found in configuration files." }
 	, { TDSESOCK,              EXCOMM,	"Unable to open socket" }
-	, { TDSESYNC,              EXCOMM,	"Read attempted while out of synchronization with Adaptive Server" }
+	, { TDSESYNC,              EXCOMM,	"Read attempted while out of synchronization with TDS server" }
 	, { TDSEUHST,	           EXUSER,	"Unknown host machine name." }
 	, { TDSEUMSG,              EXCOMM,	"Unknown message-id in MSG datastream" }
 	, { TDSEUSCT,              EXCOMM,	"Unable to set communications timer" }


### PR DESCRIPTION
FreeTDS works with both Adaptive Server and Microsoft SQL Server, so a generic term should be used that works for both servers.