### PR TITLE
Improve Scorecard score

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,6 +19,9 @@ on:
 
     workflow_dispatch:
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
 
     build:
@@ -57,7 +60,7 @@ jobs:
 
         steps:
 
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
         - name: Install dependencies
           run: |
@@ -112,7 +115,7 @@ jobs:
 
         - name: Archive test results on failure
           if: failure()
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
           with:
             name: test-logs
             path: |
@@ -132,7 +135,7 @@ jobs:
 
         steps:
 
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
         - name: Install dependencies
           run: |
@@ -149,7 +152,7 @@ jobs:
           run: make dist
 
         - name: Archive archives
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
           with:
             name: dist
             path: freetds-*.tar.*

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,6 +19,9 @@ on:
 
     workflow_dispatch:
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
 
     build:
@@ -34,7 +37,7 @@ jobs:
 
         steps:
 
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
           with:
             fetch-depth: 0
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,6 +19,9 @@ on:
 
     workflow_dispatch:
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
 
     build:
@@ -37,11 +40,11 @@ jobs:
 
         steps:
 
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
           with:
             fetch-depth: 0
 
-        - uses: ilammy/msvc-dev-cmd@v1
+        - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
         - name: Install OpenSSL & perf
           run: |


### PR DESCRIPTION

freetds now has a score of 3.7
![image](https://github.com/user-attachments/assets/1f6d21ae-681c-4acf-b721-5966f7c9b698)
https://scorecard.dev/viewer/?uri=github.com/FreeTDS/freetds

This PR improves the scores for check items'Token-Permissions' and'Pinned-Dependencies'.

Background:
The company has a minimum rating requirement for open-source software in use; software must have a score higher than 4 to be introduced and utilized. 


