### PR TITLE
Update workflows to improve scorecard scores

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -60,7 +60,7 @@ jobs:
 
         steps:
 
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
         - name: Install dependencies
           run: |
@@ -115,7 +115,7 @@ jobs:
 
         - name: Archive test results on failure
           if: failure()
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
           with:
             name: test-logs
             path: |
@@ -135,7 +135,7 @@ jobs:
 
         steps:
 
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
         - name: Install dependencies
           run: |
@@ -152,7 +152,7 @@ jobs:
           run: make dist
 
         - name: Archive archives
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
           with:
             name: dist
             path: freetds-*.tar.*

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,6 +19,9 @@ on:
 
     workflow_dispatch:
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
 
     build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
 
         steps:
 
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
           with:
             fetch-depth: 0
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,6 +19,9 @@ on:
 
     workflow_dispatch:
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
 
     build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,11 +40,11 @@ jobs:
 
         steps:
 
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
           with:
             fetch-depth: 0
 
-        - uses: ilammy/msvc-dev-cmd@v1
+        - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
         - name: Install OpenSSL & perf
           run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,6 +19,9 @@ on:
 
     workflow_dispatch:
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
 
     build:


### PR DESCRIPTION
1. Set default workflow permissions to read-only
2. Workflow dependencies pinned using hash values