### PR TITLE
Let array test pass with Microsoft ODBC driver

### DIFF
--- a/src/odbc/unittests/array.c
+++ b/src/odbc/unittests/array.c
@@ -65,7 +65,7 @@ query_test(int prepare, SQLRETURN expected, const char *expected_status)
 	}
 
 	for (i = 1; CHKGetDiagRec(SQL_HANDLE_STMT, odbc_stmt, i, state, NULL, err, sizeof(odbc_err), NULL, "SINo") != SQL_NO_DATA; ++i) {
-		SQLINTEGER row;
+		SQLINTEGER row = 0;
 
 		strcpy(odbc_err, C(err));
 		strcpy(odbc_sqlstate, C(state));

--- a/src/odbc/unittests/array.c
+++ b/src/odbc/unittests/array.c
@@ -152,12 +152,12 @@ main(void)
 		/* all errors */
 		test_query = T("INSERT INTO #tmp1 (id, value) VALUES (?, ?)");
 		multiply = 257;
-		query_test(0, SQL_ERROR, "!!!!!!!!!!");
+		query_test(0, odbc_driver_is_freetds() ? SQL_ERROR : SQL_SUCCESS_WITH_INFO, "!!!!!!!!!!");
 		multiply = 257;
 		query_test(1, SQL_SUCCESS_WITH_INFO, "!!!!!!!!!!");
 
 		test_query = T("INSERT INTO #tmp1 (id, value) VALUES (?, ?)");
-		query_test(0, SQL_ERROR, "VV!!!!!!!!");
+		query_test(0, odbc_driver_is_freetds() ? SQL_ERROR : SQL_SUCCESS_WITH_INFO, "VV!!!!!!!!");
 		query_test(1, SQL_SUCCESS_WITH_INFO, "VV!!!!!!!!");
 
 		test_query = T("INSERT INTO #tmp1 (id, value) VALUES (900-?, ?)");
@@ -165,7 +165,7 @@ main(void)
 		query_test(1, SQL_SUCCESS_WITH_INFO, "!!!!!!!VVV");
 
 		test_query = T("INSERT INTO #tmp1 (id) VALUES (?) UPDATE #tmp1 SET value = ?");
-		query_test(0, SQL_SUCCESS_WITH_INFO, "VVVV!V!V!V");
+		query_test(0, SQL_SUCCESS_WITH_INFO, odbc_driver_is_freetds() ? "VVVV!V!V!V" : "VV!!!!!!!!");
 		query_test(1, SQL_SUCCESS_WITH_INFO, "VV!!!!!!!!");
 
 #ifdef ENABLE_DEVELOPING


### PR DESCRIPTION
I'd like the test to pass with this driver too to be able to compare behaviour between FreeTDS and it easier, so I hope these changes could be applied (if not, I'll just keep them in a local branch but this will mean more juggling with branches for me).