### PR TITLE
More robust filename comparison on log_elision.c

### DIFF
--- a/src/tds/unittests/log_elision.c
+++ b/src/tds/unittests/log_elision.c
@@ -35,6 +35,8 @@ enum {
 	THREADS = 3,
 };
 
+#define CONCAT(a, b) a##b
+
 static TDS_THREAD_PROC_DECLARE(log_func, idx_ptr)
 {
 	const int idx = TDS_PTR2INT(idx_ptr);
@@ -117,7 +119,7 @@ TEST_MAIN()
 			continue;
 		}
 
-		ret = sscanf(line, "log_elision.c:%d:Some log from %c number %d\n",
+		ret = sscanf(line, CONCAT(__FILE__, ":%d:Some log from %c number %d\n"),
 			     &num_line, &thread_letter, &num);
 		assert(ret == 3);
 


### PR DESCRIPTION
__FILE__ on VMS includes the absolute path and version number, like so:

DKA0:[CRAIG.freetds-1^.5rc2.src.tds.unittests]log_elision.c;1

which was not matching the sscanf pattern in the test. So just concatenate __FILE__ (after expansion) onto the parts that are stable.