### PR TITLE
Support Sybase/ASE SSL

### DIFF
--- a/src/tds/config.c
+++ b/src/tds/config.c
@@ -1465,16 +1465,21 @@ tds_get_compiletime_settings(void)
 TDSRET
 tds8_adjust_login(TDSLOGIN *login)
 {
-	if (!IS_TDS80_PLUS(login) && login->encryption_level != TDS_ENCRYPTION_STRICT)
-		return TDS_SUCCESS;
+	// TDS 8.0 requires TDS_ENCRYPTION_STRICT (entire-connection encryption)
+	if (IS_TDS80_PLUS(login))
+		login->encryption_level = TDS_ENCRYPTION_STRICT;
 
-	login->tds_version = 0x800;
-	login->encryption_level = TDS_ENCRYPTION_STRICT;
+	if (login->encryption_level == TDS_ENCRYPTION_STRICT)
+	{
+		// TDS 5.0 (Sybase/SAP ASE) it is optional; but TDS 7.x does not allow it.
+		// So, try 8.0 unless they specifically requested 5.0
+		if (!IS_TDS50(login) && !IS_TDS80_PLUS(login))
+			login->tds_version = 0x800;
 
-	/* we must have certificates */
-	if (tds_dstr_isempty(&login->cafile)) {
-		if (!tds_dstr_copy(&login->cafile, "system"))
-			return -TDSEMEM;
+		// Validate server certificate signature to reduce risk of MITM attacks
+		if (tds_dstr_isempty(&login->cafile))
+			if (!tds_dstr_copy(&login->cafile, "system"))
+				return -TDSEMEM;
 	}
 
 	return TDS_SUCCESS;

--- a/src/tds/login.c
+++ b/src/tds/login.c
@@ -684,6 +684,11 @@ reroute:
 		db_selected = true;
 	} else {
 		tds->out_flag = TDS_LOGIN;
+
+		/* SAP ASE 15.0+ SSL mode encrypts entire connection (like stunnel) */
+		if (login->encryption_level == TDS_ENCRYPTION_STRICT)
+			TDS_PROPAGATE(tds_ssl_init(tds, true));
+
 		erc = tds_send_login(tds, login);
 	}
 	if (TDS_FAILED(erc) || TDS_FAILED(tds_process_login_tokens(tds))) {


### PR DESCRIPTION
See [issue 511](https://github.com/FreeTDS/freetds/issues/511)

Sybase SSL behaves like cleartext Sybase behind a Stunnel.

Added in that the TDS 5 login will honour TDS_ENCRYPTION_STRICT; but also had to modify `tds8_adjust_login()` to not perform adjustments if it's TDS 5.

Note that the CA certificate step is NOT necessary for ASE (and in fact breaks the handshake if I add that in, but that could also be due to a configuration error in my setup). 

