### PR TITLE
Better test for vasprintf on VMS

### DIFF
--- a/vms/config_h.vms
+++ b/vms/config_h.vms
@@ -237,7 +237,9 @@
 #define HAVE_SNPRINTF @D_SNPRINTF@
 
 /* Define to 1 if you have the `vsnprintf' function. */
-#define HAVE_VSNPRINTF 0
+#if __CRTL_VER >= 70302000
+#define HAVE_VSNPRINTF 1
+#endif
 
 /* Define as const if the declaration of iconv() needs const. */
 #if HAVE_ICONV

--- a/vms/configure.com
+++ b/vms/configure.com
@@ -267,14 +267,23 @@ $!
 $! Check for vasprintf
 $!
 $ OS
-$ WS "#include <stdarg.h>"
 $ WS "#include <stdio.h>"
 $ WS "#include <stdlib.h>"
-$ WS "int main()"
+$ WS "#include <stdarg.h>"
+$ WS "void try_vasprintf(const char *fmt, ...)"
 $ WS "{"
-$ WS "char *ptr;
-$ WS "vasprintf(&ptr,""%d,%d"",1,2);"
-$ WS "exit(0);"
+$ WS "    char* dyn_buf;"
+$ WS "    va_list args;"
+$ WS "    va_start(args, fmt);"
+$ WS "    const int written = vasprintf(&dyn_buf, fmt, args);"
+$ WS "    va_end(args);"
+$ WS "    free(dyn_buf);"
+$ WS "    if (written == 18) exit(0);"
+$ WS "    exit(1);"
+$ WS "}"
+$ WS "int main(void)"
+$ WS "{"
+$ WS "    try_vasprintf(""Testing... %d, %d, %d"", 1, 2, 3);"
 $ WS "}"
 $ CS
 $ tmp = "vasprintf"


### PR DESCRIPTION
Recentish CRTLs do have it, but the test I added 23 years ago was not correctly detecting it.