### PR TITLE
tds: fix potential NULL dereference

### DIFF
--- a/src/tds/token.c
+++ b/src/tds/token.c
@@ -2541,7 +2541,7 @@ tds_alloc_get_string(TDSSOCKET * tds, char **string, size_t len)
 		*string = NULL;
 		return -1;
 	}
-	s = (char*) realloc(s, out_len + 1);
+	TDS_RESIZE(s, out_len + 1);
 	s[out_len] = '\0';
 	*string = s;
 	return 0;


### PR DESCRIPTION
The result of the realloc function can be NULL if the memory allocation fails.
Found by PostgresPro with Svace Static Analyzer
