### PR TITLE
dblib: avoid potential NULL dereference

### DIFF
--- a/src/dblib/dblib.c
+++ b/src/dblib/dblib.c
@@ -254,6 +254,11 @@ dblib_get_tds_ctx(void)
 	if (g_dblib_ctx.tds_ctx == NULL) {
 		g_dblib_ctx.tds_ctx = tds_alloc_context(&g_dblib_ctx);
 
+		if (g_dblib_ctx.tds_ctx == NULL) {
+			tds_mutex_unlock(&dblib_mutex);
+			return NULL;
+		}
+
 		/*
 		 * Set the functions in the TDS layer to point to the correct handler functions
 		 */


### PR DESCRIPTION
tds_alloc_context() may return NULL, and the returned value should be checked before being dereferenced.

Found by PostgresPro