### PR TITLE
BCP hostfile read buffering

### DIFF
--- a/include/freetds/tds.h
+++ b/include/freetds/tds.h
@@ -1749,8 +1749,10 @@ TDSRET tds_bcp_done(TDSSOCKET *tds, int *rows_copied);
 TDSRET tds_bcp_start(TDSSOCKET *tds, TDSBCPINFO *bcpinfo);
 TDSRET tds_bcp_start_copy_in(TDSSOCKET *tds, TDSBCPINFO *bcpinfo);
 
-TDSRET tds_bcp_fread(TDSSOCKET * tds, TDSICONV * conv, FILE * stream,
-		     const char *terminator, size_t term_len, char **outbuf, size_t * outbytes);
+struct tds_file_stream;
+TDSRET
+tds_bcp_fread(TDSSOCKET* tds, TDSICONV* char_conv, struct tds_file_stream* stream,
+			 const char *terminator, size_t term_len, char** outbuf, size_t* outbytes);
 
 TDSRET tds_writetext_start(TDSSOCKET *tds, const char *objname, const char *textptr, const char *timestamp, int with_log, TDS_UINT size);
 TDSRET tds_writetext_continue(TDSSOCKET *tds, const TDS_UCHAR *text, TDS_UINT size);

--- a/include/freetds/tds/stream.h
+++ b/include/freetds/tds/stream.h
@@ -28,6 +28,27 @@
 #include <freetds/tds/iconv.h>	/* TDS_ICONV_DIRECTION */
 #include <freetds/pushvis.h>
 
+ /* Support 64-bit file seek if possible */
+#ifdef HAVE_FSEEKO
+typedef off_t offset_type;
+#elif defined(_WIN32) || defined(_WIN64)
+/* win32 version */
+typedef __int64 offset_type;
+# if defined(HAVE__FSEEKI64) && defined(HAVE__FTELLI64)
+#  define fseeko(f,o,w) _fseeki64((f),o,w)
+#  define ftello(f) _ftelli64((f))
+# else
+#  define fseeko(f,o,w) (_lseeki64(fileno(f),o,w) == -1 ? -1 : 0)
+#  define ftello(f) _telli64(fileno(f))
+# endif
+#else
+/* use old version */
+#define fseeko(f,o,w) fseek(f,o,w)
+#define ftello(f) ftell(f)
+typedef long offset_type;
+#endif
+
+
 /** define a stream of data used for input */
 typedef struct tds_input_stream {
 	/** read some data
@@ -129,7 +150,11 @@ typedef struct tds_dynamic_stream {
 TDSRET tds_dynamic_stream_init(TDSDYNAMICSTREAM * stream, void **ptr, size_t allocated);
 
 /* input stream to read a file with option to terminate the read
- * when a delimiter sequence is read
+ * when a delimiter sequence is read.
+ * 
+ * This structure may read more byte from the file than are consumed by this
+ * operation. This structure expects no other seek, read or write operations
+ * are performed on the file pointer while it's active in this structure.
  */
 typedef struct tds_file_stream
 {
@@ -151,9 +176,18 @@ typedef struct tds_file_stream
 	size_t term_len;
 } TDSFILESTREAM;
 
+TDSRET
+tds_file_stream_init(TDSFILESTREAM* stream, FILE* f);
+
 /** Use a terminator for subsequent reads - Does not strdup the terminator, so be careful not to leave dangling */
 TDSRET tds_file_stream_use_terminator(TDSFILESTREAM* stream, const char* term, size_t term_len);
 
+/** Read raw data from stream (no terminator or iconv). Return number of bytes read. */
+size_t tds_file_stream_read_raw(TDSFILESTREAM* stream, void* ptr, size_t n);
+TDSRET tds_file_stream_seek_set(TDSFILESTREAM* stream, offset_type seek_to);
+offset_type tds_file_stream_tell(TDSFILESTREAM* stream);
+/** Close the stream's file handle and reset the stream (optional) */
+TDSRET tds_file_stream_close(TDSFILESTREAM* stream);
 #include <freetds/popvis.h>
 
 #endif

--- a/include/freetds/tds/stream.h
+++ b/include/freetds/tds/stream.h
@@ -156,6 +156,8 @@ TDSRET tds_dynamic_stream_init(TDSDYNAMICSTREAM * stream, void **ptr, size_t all
  * operation. This structure expects no other seek, read or write operations
  * are performed on the file pointer while it's active in this structure.
  */
+enum { TDSFILESTREAM_BLOCKSIZE = 512 };
+
 typedef struct tds_file_stream
 {
 	/** common fields, must be the first field */
@@ -174,6 +176,12 @@ typedef struct tds_file_stream
 	 */
 	char const* terminator;
 	size_t term_len;
+
+	/* Read buffering */
+	char inbuf[TDSFILESTREAM_BLOCKSIZE];
+	size_t inpos;
+	size_t inlen;
+
 } TDSFILESTREAM;
 
 TDSRET

--- a/include/freetds/tds/stream.h
+++ b/include/freetds/tds/stream.h
@@ -139,20 +139,20 @@ typedef struct tds_file_stream
 	/** file to read from */
 	FILE *f;
 
-	/** Circular input buffer followed by 2 copies of the terminator
-	 * so that we can easily "memcmp" the circular buffer against it
-	 */
-	char *cbuf;
-	/** Offset in circular buffer of last-read character */
+	/** Circular buffer of fixed size (to avoid malloc overhead);
+	 * assume nobody is going to use a gigantic terminator... */
+	char cbuf[50];
 	size_t cpos;
 
-	/** terminator length in bytes -- cbuf length is 3*term_len */
+	/** Terminator to compare against - Memory not owned by the TDSFILESTREAM;
+	 * make sure to not leave danging pointers here.
+	 */
+	char const* terminator;
 	size_t term_len;
 } TDSFILESTREAM;
 
-TDSRET tds_file_stream_init(TDSFILESTREAM * stream, FILE * f);
-TDSRET tds_file_stream_set_terminator(TDSFILESTREAM * stream, const char *term, size_t term_len);
-TDSRET tds_file_stream_destroy(TDSFILESTREAM * stream);
+/** Use a terminator for subsequent reads - Does not strdup the terminator, so be careful not to leave dangling */
+TDSRET tds_file_stream_use_terminator(TDSFILESTREAM* stream, const char* term, size_t term_len);
 
 #include <freetds/popvis.h>
 

--- a/src/dblib/bcp.c
+++ b/src/dblib/bcp.c
@@ -59,25 +59,6 @@
 #define HOST_COL_CONV_ERROR 1
 #define HOST_COL_NULL_ERROR 2
 
-#ifdef HAVE_FSEEKO
-typedef off_t offset_type;
-#elif defined(_WIN32) || defined(_WIN64)
-/* win32 version */
-typedef __int64 offset_type;
-# if defined(HAVE__FSEEKI64) && defined(HAVE__FTELLI64)
-#  define fseeko(f,o,w) _fseeki64((f),o,w)
-#  define ftello(f) _ftelli64((f))
-# else
-#  define fseeko(f,o,w) (_lseeki64(fileno(f),o,w) == -1 ? -1 : 0)
-#  define ftello(f) _telli64(fileno(f))
-# endif
-#else
-/* use old version */
-#define fseeko(f,o,w) fseek(f,o,w)
-#define ftello(f) ftell(f)
-typedef long offset_type;
-#endif
-
 static void _bcp_free_storage(DBPROCESS * dbproc);
 static void _bcp_free_columns(DBPROCESS * dbproc);
 static void _bcp_null_error(TDSBCPINFO *bcpinfo, int index, int offset);
@@ -86,7 +67,7 @@ static TDSRET _bcp_no_get_col_data(TDSBCPINFO *bcpinfo, TDSCOLUMN *bindcol, int 
 
 static int rtrim(char *, int);
 static int rtrim_u16(uint16_t *str, int len, uint16_t space);
-static STATUS _bcp_read_hostfile(DBPROCESS * dbproc, FILE * hostfile, bool *row_error, bool skip);
+static STATUS _bcp_read_hostfile(DBPROCESS * dbproc, TDSFILESTREAM * hostfile, bool *row_error, bool skip);
 static int _bcp_readfmt_colinfo(DBPROCESS * dbproc, char *buf, BCP_HOSTCOLINFO * ci);
 static int _bcp_get_term_var(const BYTE * pdata, const BYTE * term, int term_len);
 static int _bcp_strftime(char *buf, size_t maxsize, const char *format, const TDSDATEREC * dr, int prec);
@@ -1183,13 +1164,12 @@ rtrim_bcpcol(TDSCOLUMN *bcpcol)
  * \sa 	BCP_SETL(), bcp_batch(), bcp_bind(), bcp_colfmt(), bcp_colfmt_ps(), bcp_collen(), bcp_colptr(), bcp_columns(), bcp_control(), bcp_done(), bcp_exec(), bcp_getl(), bcp_init(), bcp_moretext(), bcp_options(), bcp_readfmt(), bcp_sendrow()
  */
 static STATUS
-_bcp_read_hostfile(DBPROCESS * dbproc, FILE * hostfile, bool *row_error, bool skip)
+_bcp_read_hostfile(DBPROCESS * dbproc, TDSFILESTREAM *stream, bool *row_error, bool skip)
 {
 	int i;
 
-	tdsdump_log(TDS_DBG_FUNC, "_bcp_read_hostfile(%p, %p, %p, %d)\n", dbproc, hostfile, row_error, skip);
+	tdsdump_log(TDS_DBG_FUNC, "_bcp_read_hostfile(%p, %p, %p, %d)\n", dbproc, stream, row_error, skip);
 	assert(dbproc);
-	assert(hostfile);
 	assert(row_error);
 
 	/* for each host file column defined by calls to bcp_colfmt */
@@ -1238,18 +1218,18 @@ _bcp_read_hostfile(DBPROCESS * dbproc, FILE * hostfile, bool *row_error, bool sk
 
 			switch (hostcol->prefix_len) {
 			case 1:
-				if (fread(&u.ti, 1, 1, hostfile) != 1)
-					return _bcp_check_eof(dbproc, hostfile, i);
+				if (tds_file_stream_read_raw(stream, &u.ti, 1) != 1)
+					return _bcp_check_eof(dbproc, stream->f, i);
 				collen = u.ti ? u.ti : -1;
 				break;
 			case 2:
-				if (fread(&u.si, 2, 1, hostfile) != 1)
-					return _bcp_check_eof(dbproc, hostfile, i);
+				if (tds_file_stream_read_raw(stream, &u.si, 2) != 2)
+					return _bcp_check_eof(dbproc, stream->f, i);
 				collen = u.si;
 				break;
 			case 4:
-				if (fread(&u.li, 4, 1, hostfile) != 1)
-					return _bcp_check_eof(dbproc, hostfile, i);
+				if (tds_file_stream_read_raw(stream, &u.li, 4) != 4)
+					return _bcp_check_eof(dbproc, stream->f, i);
 				collen = u.li;
 				break;
 			default:
@@ -1284,7 +1264,7 @@ _bcp_read_hostfile(DBPROCESS * dbproc, FILE * hostfile, bool *row_error, bool sk
 		if (is_fixed_type(hostcol->datatype))
 			collen = tds_get_size_by_type(hostcol->datatype);
 
-		col_start = ftello(hostfile);
+		col_start = tds_file_stream_tell(stream);
 
 		/*
 		 * The data file either contains prefixes stating the length, or is delimited.  
@@ -1295,11 +1275,8 @@ _bcp_read_hostfile(DBPROCESS * dbproc, FILE * hostfile, bool *row_error, bool sk
 			size_t col_bytes;
 			TDSRET conv_res;
 
-			/* 
-			 * Read and convert the data
-			 */
 			coldata = NULL;
-			conv_res = tds_bcp_fread(dbproc->tds_socket, bcpcol ? bcpcol->char_conv : NULL, hostfile,
+			conv_res = tds_bcp_fread(dbproc->tds_socket, bcpcol ? bcpcol->char_conv : NULL, stream,
 						 (const char *) hostcol->terminator, hostcol->term_len, &coldata, &col_bytes);
 
 			if (TDS_FAILED(conv_res)) {
@@ -1313,7 +1290,7 @@ _bcp_read_hostfile(DBPROCESS * dbproc, FILE * hostfile, bool *row_error, bool sk
 
 			if (conv_res == TDS_NO_MORE_RESULTS) {
 				free(coldata);
-				return _bcp_check_eof(dbproc, hostfile, i);
+				return _bcp_check_eof(dbproc, stream->f, i);
 			}
 
 			if (col_bytes > 0x7fffffffl) {
@@ -1358,9 +1335,9 @@ _bcp_read_hostfile(DBPROCESS * dbproc, FILE * hostfile, bool *row_error, bool sk
 				 *	 call and test it. 
 				 */
 				tdsdump_log(TDS_DBG_FUNC, "Reading %d bytes from hostfile.\n", collen);
-				if (fread(coldata, collen, 1, hostfile) != 1) {
+				if (tds_file_stream_read_raw(stream, coldata, collen) != collen) {
 					free(coldata);
-					return _bcp_check_eof(dbproc, hostfile, i);
+					return _bcp_check_eof(dbproc, stream->f, i);
 				}
 			}
 		}
@@ -1478,7 +1455,8 @@ bcp_sendrow(DBPROCESS * dbproc)
 static RETCODE
 _bcp_exec_in(DBPROCESS * dbproc, DBINT * rows_copied)
 {
-	FILE *hostfile, *errfile = NULL;
+	FILE *errfile = NULL;
+	TDSFILESTREAM hoststream;
 	TDSSOCKET *tds = dbproc->tds_socket;
 	BCP_HOSTCOLINFO *hostcol;
 	STATUS ret;
@@ -1496,13 +1474,16 @@ _bcp_exec_in(DBPROCESS * dbproc, DBINT * rows_copied)
 
 	*rows_copied = 0;
 	
-	if (!(hostfile = fopen(dbproc->hostfileinfo->hostfile, "r"))) {
+	if (!TDS_SUCCEED(tds_file_stream_init(&hoststream, 
+			fopen(dbproc->hostfileinfo->hostfile, "r"))))
+	{
+		tdsdump_log(TDS_DBG_FUNC, "error: cannot initialize hostfile stream");
 		dbperror(dbproc, SYBEBCUO, 0);
 		return FAIL;
 	}
 
 	if (TDS_FAILED(tds_bcp_start_copy_in(tds, dbproc->bcpinfo))) {
-		fclose(hostfile);
+		tds_file_stream_close(&hoststream);
 		return FAIL;
 	}
 
@@ -1515,7 +1496,7 @@ _bcp_exec_in(DBPROCESS * dbproc, DBINT * rows_copied)
 	for (;;) {
 		bool skip;
 
-		row_start = ftello(hostfile);
+		row_start = tds_file_stream_tell(&hoststream);
 		row_error = false;
 
 		row_of_hostfile++;
@@ -1524,7 +1505,7 @@ _bcp_exec_in(DBPROCESS * dbproc, DBINT * rows_copied)
 			break;
 
 		skip = dbproc->hostfileinfo->firstrow > row_of_hostfile;
-		ret = _bcp_read_hostfile(dbproc, hostfile, &row_error, skip);
+		ret = _bcp_read_hostfile(dbproc, &hoststream, &row_error, skip);
 		if (ret != MORE_ROWS)
 			break;
 
@@ -1533,7 +1514,7 @@ _bcp_exec_in(DBPROCESS * dbproc, DBINT * rows_copied)
 
 			if (errfile == NULL && dbproc->hostfileinfo->errorfile) {
 				if (!(errfile = fopen(dbproc->hostfileinfo->errorfile, "w"))) {
-					fclose(hostfile);
+					tds_file_stream_close(&hoststream);
 					dbperror(dbproc, SYBEBUOE, 0);
 					return FAIL;
 				}
@@ -1562,11 +1543,11 @@ _bcp_exec_in(DBPROCESS * dbproc, DBINT * rows_copied)
 					}
 				}
 
-				row_end = ftello(hostfile);
+				row_end = tds_file_stream_tell(&hoststream);
 
 				/* error data can be very long so split in chunks */
 				error_row_size = row_end - row_start;
-				fseeko(hostfile, row_start, SEEK_SET);
+				tds_file_stream_seek_set(&hoststream, row_start);
 
 				while (error_row_size > 0) {
 					size_t chunk = TDS_MIN((size_t) error_row_size, chunk_size);
@@ -1578,7 +1559,7 @@ _bcp_exec_in(DBPROCESS * dbproc, DBINT * rows_copied)
 						}
 					}
 
-					if (fread(row_in_error, 1, chunk, hostfile) != chunk)
+					if (tds_file_stream_read_raw(&hoststream, row_in_error, chunk) != chunk)
 						tdsdump_log(TDS_DBG_ERROR, "BILL fread failed after fseek\n");
 
 					written = fwrite(row_in_error, 1, chunk, errfile);
@@ -1589,7 +1570,7 @@ _bcp_exec_in(DBPROCESS * dbproc, DBINT * rows_copied)
 				}
 				free(row_in_error);
 
-				fseeko(hostfile, row_end, SEEK_SET);
+				tds_file_stream_seek_set(&hoststream, row_start);
 				count = fprintf(errfile, "\n");
 				if( count < 0 ) {
 					dbperror(dbproc, SYBEBWEF, errno);
@@ -1613,7 +1594,7 @@ _bcp_exec_in(DBPROCESS * dbproc, DBINT * rows_copied)
 				if (TDS_FAILED(tds_bcp_done(tds, &rows_written_so_far))) {
 					if (errfile)
 						fclose(errfile);
-					fclose(hostfile);
+					tds_file_stream_close(&hoststream);
 					return FAIL;
 				}
 
@@ -1636,7 +1617,7 @@ _bcp_exec_in(DBPROCESS * dbproc, DBINT * rows_copied)
 		dbperror(dbproc, SYBEBUCE, 0);
 	}
 
-	if (fclose(hostfile) != 0) {
+	if (TDS_FAILED(tds_file_stream_close(&hoststream))) {
 		dbperror(dbproc, SYBEBCUC, 0);
 		ret = FAIL;
 	}

--- a/src/dblib/bcp.c
+++ b/src/dblib/bcp.c
@@ -1180,7 +1180,7 @@ _bcp_read_hostfile(DBPROCESS * dbproc, TDSFILESTREAM *stream, bool *row_error, b
 		TDS_CHAR *coldata;
 		int collen = 0;
 		bool data_is_null = false;
-		offset_type col_start;
+		offset_type col_start = 0;
 
 		tdsdump_log(TDS_DBG_FUNC, "parsing host column %d\n", i + 1);
 		hostcol = dbproc->hostfileinfo->host_columns[i];
@@ -1264,8 +1264,10 @@ _bcp_read_hostfile(DBPROCESS * dbproc, TDSFILESTREAM *stream, bool *row_error, b
 		if (is_fixed_type(hostcol->datatype))
 			collen = tds_get_size_by_type(hostcol->datatype);
 
+#if ENABLE_EXTRA_CHECKS
+		/* Expensive operation for a hot loop */
 		col_start = tds_file_stream_tell(stream);
-
+#endif
 		/*
 		 * The data file either contains prefixes stating the length, or is delimited.  
 		 * If delimited, we "measure" the field by looking for the terminator, then read it, 
@@ -1361,8 +1363,10 @@ _bcp_read_hostfile(DBPROCESS * dbproc, TDSFILESTREAM *stream, bool *row_error, b
 				if (TDS_FAILED(rc)) {
 					hostcol->column_error = HOST_COL_CONV_ERROR;
 					*row_error = true;
+					if ( col_start == 0 )
+						col_start = tds_file_stream_tell(stream) - collen;
 					tdsdump_log(TDS_DBG_FUNC, 
-						"_bcp_read_hostfile failed to convert %d bytes at offset 0x%" PRIx64 " in the data file.\n",
+						"_bcp_read_hostfile failed to convert %d bytes at offset about 0x%" PRIx64 " in the data file.\n",
 						    collen, (TDS_INT8) col_start);
 				}
 

--- a/src/tds/bulk.c
+++ b/src/tds/bulk.c
@@ -1433,6 +1433,18 @@ tds_bcp_start_copy_in(TDSSOCKET *tds, TDSBCPINFO *bcpinfo)
 #endif
 /** \endcond */
 
+/** Check if a circular buffer matches a string of same length. Requires length > 0.  */
+static int cbuf_match(char const* cbuf, size_t cbuf_size, size_t cpos, char const* match)
+{
+	if (cbuf_size == 1)
+		return cbuf[0] == match[0];
+	else if (cbuf_size == 2)
+		return cbuf[cpos] == match[0] && cbuf[!cpos] == match[1];
+
+	return !memcmp(cbuf + cpos, match, cbuf_size - cpos)
+		&& !memcmp(cbuf, match + cbuf_size - cpos, cpos);
+}
+
 /**
  * Reads a chunk of data from file stream checking for terminator
  * \param stream file stream
@@ -1447,8 +1459,7 @@ tds_file_stream_read(TDSINSTREAM *stream, void *ptr, size_t len)
 	char *p = (char *) ptr;
 
 	while (len) {
-		/* Check if the circular buffer contains a terminator */
-		if (memcmp(s->cbuf, s->cbuf + 2 * s->term_len - s->cpos, s->term_len) == 0)
+		if ( cbuf_match(s->cbuf, s->term_len, s->cpos, s->terminator) )
 			return p - (char *) ptr;
 
 		/* It didn't; output from the circular buffer and input a new character */
@@ -1475,48 +1486,30 @@ tds_file_stream_init(TDSFILESTREAM *stream, FILE *f)
 	return TDS_SUCCESS;
 }
 
-TDSRET
-tds_file_stream_destroy(TDSFILESTREAM *stream)
-{
-	free(stream->cbuf);
-	stream->cbuf = NULL;
-	return TDS_SUCCESS;
-}
-
 /** Sets the terminator and also performs an initial population of the circular buffer */
-TDSRET
-tds_file_stream_set_terminator(TDSFILESTREAM *stream, const char *term, size_t term_len)
+TDSRET tds_file_stream_use_terminator(TDSFILESTREAM* stream, const char* term, size_t term_len)
 {
 	size_t readed;
-	void *newbuf;
 
-	if (!term_len) {
-		stream->term_len = 0;
-		return TDS_SUCCESS;
-	}
-
-	/* Allocate the circular buffer */
-	newbuf = realloc(stream->cbuf, term_len * 3);
-	if (!newbuf)
+	if (term_len > sizeof stream->cbuf)
 		return TDS_FAIL;
+
+	stream->terminator = term;
+	stream->term_len = term_len;
+	stream->cpos = 0;
+
+	if (term_len == 0)
+		return TDS_SUCCESS;
 
 	/* Have to have initial data to populate the circular buffer (if the file contains
 	 * less data than the length of 1 expected terminator, it means file is corrupt)
 	 */
-	readed = fread(newbuf, 1, term_len, stream->f);
+	readed = fread(stream->cbuf, 1, term_len, stream->f);
 	if (readed != term_len) {
-		free(newbuf);
 		if (readed == 0 && feof(stream->f))
 			return TDS_NO_MORE_RESULTS;
 		return TDS_FAIL;
 	}
-
-	/* Finish setting up the stream structure */
-	stream->cpos = 0;
-	stream->cbuf = newbuf;
-	stream->term_len = term_len;
-	memcpy(stream->cbuf + term_len, term, term_len);
-	memcpy(stream->cbuf + term_len * 2, term, term_len);
 
 	return TDS_SUCCESS;
 }
@@ -1536,13 +1529,12 @@ tds_bcp_fread(TDSSOCKET * tds, TDSICONV * char_conv, FILE * stream, const char *
 
 	/* prepare streams */
 	TDS_PROPAGATE(tds_file_stream_init(&r, stream));
-	res = tds_file_stream_set_terminator(&r, terminator, term_len);
+	res = tds_file_stream_use_terminator(&r, terminator, term_len);
 	if (res != TDS_SUCCESS)	/* Also return if TDS_NO_MORE_RESULTS */
 		return res;
 
 	res = tds_dynamic_stream_init(&w, (void **) outbuf, 0);
 	if (TDS_FAILED(res)) {
-		tds_file_stream_destroy(&r);
 		return res;
 	}
 
@@ -1553,7 +1545,6 @@ tds_bcp_fread(TDSSOCKET * tds, TDSICONV * char_conv, FILE * stream, const char *
 	else
 		res = tds_convert_stream(tds, char_conv, to_server, &r.stream, &w.stream);
 	funlockfile(stream);
-	tds_file_stream_destroy(&r);
 
 	TDS_PROPAGATE(res);
 

--- a/src/tds/bulk.c
+++ b/src/tds/bulk.c
@@ -1477,15 +1477,32 @@ tds_file_stream_read(TDSINSTREAM *stream, void *ptr, size_t len)
 	return p - (char *) ptr;
 }
 
+/* Read raw data from stream (no terminator or iconv) */
+size_t tds_file_stream_read_raw(TDSFILESTREAM* stream, void* ptr, size_t n)
+{
+	size_t n_read = fread(ptr, 1, n, stream->f);
+	return n_read;
+}
+
+
 TDSRET
 tds_file_stream_init(TDSFILESTREAM *stream, FILE *f)
 {
 	memset(stream, 0, sizeof(*stream));
+	if (!f)
+		return TDS_FAIL;
+
 	stream->f = f;
 	stream->stream.read = tds_file_stream_read;
 	return TDS_SUCCESS;
 }
 
+TDSRET tds_file_stream_close(TDSFILESTREAM* stream)
+{
+	int ret = stream->f ? fclose(stream->f) : 0;
+	memset(stream, 0, sizeof * stream);
+	return ret;
+}
 /** Sets the terminator and also performs an initial population of the circular buffer */
 TDSRET tds_file_stream_use_terminator(TDSFILESTREAM* stream, const char* term, size_t term_len)
 {
@@ -1514,6 +1531,22 @@ TDSRET tds_file_stream_use_terminator(TDSFILESTREAM* stream, const char* term, s
 	return TDS_SUCCESS;
 }
 
+TDSRET tds_file_stream_seek_set(TDSFILESTREAM* stream, offset_type seek_to)
+{
+	fseeko(stream->f, seek_to, SEEK_SET);
+
+	/* TODO: maybe check for fseeko errors ? Original code didn't. */
+	return TDS_SUCCESS;
+}
+offset_type tds_file_stream_tell(TDSFILESTREAM* stream)
+{
+	/* Tried caching this to avoid overhead of system call, but it turns out we can't
+	 * do that accurately because hostfile is opened in text mode and will transparently
+	 * read \r\n as \n and so on. 
+	 */
+	return ftello(stream->f);
+}
+
 /**
  * Read a data file, passing the data through iconv().
  * \retval TDS_SUCCESS  success
@@ -1521,30 +1554,39 @@ TDSRET tds_file_stream_use_terminator(TDSFILESTREAM* stream, const char* term, s
  * \retval TDS_NO_MORE_RESULTS end of file detected
  */
 TDSRET
-tds_bcp_fread(TDSSOCKET * tds, TDSICONV * char_conv, FILE * stream, const char *terminator, size_t term_len, char **outbuf, size_t * outbytes)
+tds_bcp_fread(TDSSOCKET* tds, TDSICONV* char_conv, TDSFILESTREAM* stream,
+	const char* terminator, size_t term_len, char** outbuf, size_t* outbytes)
 {
 	TDSRET res;
-	TDSFILESTREAM r;
 	TDSDYNAMICSTREAM w;
 
-	/* prepare streams */
-	TDS_PROPAGATE(tds_file_stream_init(&r, stream));
-	res = tds_file_stream_use_terminator(&r, terminator, term_len);
-	if (res != TDS_SUCCESS)	/* Also return if TDS_NO_MORE_RESULTS */
+	/* Prepare input stream, returning TDS_NO_MORE_RESULTS if there
+	 * is not enough data in the stream for even one terminator -- this
+	 * indicates a clean end-of-file being reached, as opposed to
+	 * ending the file while looking for a terminator, which will generate
+	 * a TDS_FAIL from tds_copy_stream().
+	 */
+	res = tds_file_stream_use_terminator(stream, terminator, term_len);
+	if (res != TDS_SUCCESS)
 		return res;
 
+	/* prepare output streams */
 	res = tds_dynamic_stream_init(&w, (void **) outbuf, 0);
 	if (TDS_FAILED(res)) {
 		return res;
 	}
+	TDS_PROPAGATE(tds_dynamic_stream_init(&w, (void**)outbuf, 0));
 
 	/* convert/copy from input stream to output one */
-	flockfile(stream);
+	flockfile(stream->f);
 	if (char_conv == NULL)
-		res = tds_copy_stream(&r.stream, &w.stream);
+		res = tds_copy_stream(&stream->stream, &w.stream);
 	else
-		res = tds_convert_stream(tds, char_conv, to_server, &r.stream, &w.stream);
-	funlockfile(stream);
+		res = tds_convert_stream(tds, char_conv, to_server, &stream->stream, &w.stream);
+	funlockfile(stream->f);
+
+	/* Avoid any dangling pointers */
+	tds_file_stream_use_terminator(stream, NULL, 0);
 
 	TDS_PROPAGATE(res);
 

--- a/src/tds/bulk.c
+++ b/src/tds/bulk.c
@@ -1455,7 +1455,7 @@ static int
 tds_file_stream_read(TDSINSTREAM *stream, void *ptr, size_t len)
 {
 	TDSFILESTREAM *s = (TDSFILESTREAM *) stream;
-	int c;
+	char ch;
 	char *p = (char *) ptr;
 
 	while (len) {
@@ -1463,14 +1463,13 @@ tds_file_stream_read(TDSINSTREAM *stream, void *ptr, size_t len)
 			return p - (char *) ptr;
 
 		/* It didn't; output from the circular buffer and input a new character */
-		c = getc_unlocked(s->f);
-		if (c == EOF)
+		if (tds_file_stream_read_raw(s, &ch, 1) != 1)
 			return -1;
 
 		*p++ = s->cbuf[s->cpos];
 		--len;
 
-		s->cbuf[s->cpos++] = c;
+		s->cbuf[s->cpos++] = ch;
 		if (s->cpos == s->term_len)
 			s->cpos = 0;
 	}
@@ -1480,8 +1479,36 @@ tds_file_stream_read(TDSINSTREAM *stream, void *ptr, size_t len)
 /* Read raw data from stream (no terminator or iconv) */
 size_t tds_file_stream_read_raw(TDSFILESTREAM* stream, void* ptr, size_t n)
 {
-	size_t n_read = fread(ptr, 1, n, stream->f);
-	return n_read;
+	char* cptr = ptr;
+
+	while (n)
+	{
+		size_t chunk;
+
+		/* Buffer some more data if we consumed it all */
+		if (stream->inlen == stream->inpos)
+		{
+			stream->inpos = 0;
+			stream->inlen = fread(stream->inbuf, 1, TDSFILESTREAM_BLOCKSIZE, stream->f);
+			if (stream->inlen == 0)
+				break;
+		}
+
+		/* Output data from buffer */
+		chunk = stream->inlen - stream->inpos;
+		if (chunk > n)
+			chunk = n;
+
+		if (chunk > 0)
+		{
+			memcpy(cptr, stream->inbuf + stream->inpos, chunk);
+			cptr += chunk;
+			stream->inpos += chunk;
+			n -= chunk;
+		}
+	}
+
+	return cptr - (char*)ptr;
 }
 
 
@@ -1521,7 +1548,7 @@ TDSRET tds_file_stream_use_terminator(TDSFILESTREAM* stream, const char* term, s
 	/* Have to have initial data to populate the circular buffer (if the file contains
 	 * less data than the length of 1 expected terminator, it means file is corrupt)
 	 */
-	readed = fread(stream->cbuf, 1, term_len, stream->f);
+	readed = tds_file_stream_read_raw(stream, stream->cbuf, term_len);
 	if (readed != term_len) {
 		if (readed == 0 && feof(stream->f))
 			return TDS_NO_MORE_RESULTS;
@@ -1543,8 +1570,13 @@ offset_type tds_file_stream_tell(TDSFILESTREAM* stream)
 	/* Tried caching this to avoid overhead of system call, but it turns out we can't
 	 * do that accurately because hostfile is opened in text mode and will transparently
 	 * read \r\n as \n and so on. 
+	 *
+	 * Instead we will adjust it by the size of buffered data (not 100% accurate...)
 	 */
-	return ftello(stream->f);
+	offset_type ret = ftello(stream->f);
+	if (ret > 0)
+		ret -= (stream->inlen - stream->inpos);
+	return ret;
 }
 
 /**

--- a/src/tds/unittests/iconv_fread.c
+++ b/src/tds/unittests/iconv_fread.c
@@ -19,6 +19,7 @@
 
 #include "common.h"
 #include <freetds/tds/iconv.h>
+#include <freetds/tds/stream.h>
 
 #if HAVE_UNISTD_H
 #undef getpid
@@ -43,6 +44,7 @@ TEST_MAIN()
 	TDSCONTEXT *ctx = tds_alloc_context(NULL);
 	TDSSOCKET *tds = tds_alloc_socket(ctx, 512);
 	TDSICONV * conv;
+	TDSFILESTREAM stream;
 	const tds_dir_char *tdsdump;
 
 	tdsdump = tds_dir_getenv(TDS_DIR("TDSDUMP"));
@@ -65,6 +67,12 @@ TEST_MAIN()
 	f = fopen(out_file, "w+b");
 	if (!f) {
 		fprintf(stderr, "Error opening file!\n");
+		return 1;
+	}
+
+	if ( !TDS_SUCCEED(tds_file_stream_init(&stream, f)) )
+	{
+		fprintf(stderr, "Error initializing input file stream.\n");
 		return 1;
 	}
 
@@ -95,7 +103,7 @@ TEST_MAIN()
 		}
 
 		/* convert it */
-		res = tds_bcp_fread(NULL, conv, f, "!!", 2, &out, &out_len);
+		res = tds_bcp_fread(NULL, conv, &stream, "!!", 2, &out, &out_len);
 		printf("res %d out_len %u\n", (int) res, (unsigned int) out_len);
 
 		/* test */


### PR DESCRIPTION
This addresses a performance issue.  My test data set is a table with 300 small columns and 20K rows. The hostfile is about 40MB, but since FreeTDS makes a separate `fread` call for every column and every column prefix, this works out to something like 10 million `fread` and/or `fgetc` calls. 

By reading a 512-byte block at a time from the `FILE *` , I got the following performance improvements for an `in` operation:
* In Linux - `freebcp -c` improved by a factor of 2
* In VMS - `freebcp -c` improved by a factor of 4
* In VMS - `freebcp -n` improved by a factor of 10  (down from 46 seconds to 5 seconds)

The `fread`, `fgetc` functions have more overhead in VMS than in other operating systems because of how the filesystem works, it's far more efficient working in block multiples of 512.

In all cases, the database server is close to the client, so the database latency is not a factor, it can write the database faster than it can process the hostfile.  

Similar improvements are also achieved for the `out` operation by buffering the writes; that will be a subsequent PR if this one goes well.   Some users have data sets of over 1GB so any performance improvement on freebcp is quite significant.   Have not tested host files over 2GB in size.  

An increase of the block size to 32K was either the same or very fractionally better on performance, but not significantly so.

Profiling in VMS showed a lot of time spent in `ftello` (as well as `fread`): the code calls `ftello` prior to every column read, in case the read has a conversion error and the dump file needs to dump the offset where an error occurred (even if the dump file is not enabled...)    I had to rework this anyway as a side effect of adding the buffering.