### PR TITLE
Support Sybase syntax for defncopy, enabling VMS-style wrapper to work

### DIFF
--- a/src/apps/defncopy.c
+++ b/src/apps/defncopy.c
@@ -916,32 +916,35 @@ print_results(DBPROCESS *dbproc)
 static void
 usage(const char invoked_as[])
 {
+
 	fprintf(stderr, "usage:  %s \n"
-			"        [-U username] [-P password]\n"
-			"        [-S servername] [-D database]\n"
-			"        [-i input filename] [-o output filename]\n"
-			"        [owner.]object_name [[owner.]object_name...]\n"
-			, invoked_as);
-/**
-defncopy Syntax Error
-Usage: defncopy
-    [-v]
-    [-X]
---  [-a <display_charset>]
---  [-I <interfaces_file>]
---  [-J [<client_charset>]]
---  [-K <keytab_file>]
-    [-P <password>]
---  [-R <remote_server_principal>]
-    [-S [<server_name>]]
-    [-U <user_name>]
---  [-V <security_options>]
---  [-Z <security_mechanism>]
---  [-z <language>]
-    { in <file_name> <database_name> |
-      out <file_name> <database_name> [<owner>.]<object_name>
-          [[<owner>.]<object_name>...] }
-**/
+/*
+		"        [-X]\n"
+		"        [-a <display_charset>]\n"
+		"        [-I <interfaces_file>]\n"
+		"        [-J [<client_charset>]]\n"
+		"        [-K <keytab_file>]\n"
+*/
+		"        [-P <password>]\n"
+/*
+		"        [-R <remote_server_principal>]\n"
+*/
+		"        [-S [<server_name>]]\n"
+		"        [-U <user_name>]\n"
+/*
+		"        [-V <security_options>]\n"
+		"        [-Z <security_mechanism>]\n"
+		"        [-z <language>]\n"
+*/
+		"        { in <file_name> <database_name> |\n"
+		"          out <file_name> <database_name> [<owner>.]<object_name>\n"
+		"              [[<owner>.]<object_name>...] }\n"
+		"\n            OR\n\n"
+		"        %s [-U username] [-P password]\n"
+		"        [-S servername] [-D database]\n"
+		"        [-i input filename] [-o output filename]\n"
+		"        [owner.]object_name [[owner.]object_name...]\n"
+		,invoked_as, invoked_as);
 }
 
 static LOGINREC *
@@ -954,6 +957,7 @@ get_login(int argc, char *argv[], OPTIONS *options)
 
 	extern char *optarg;
 	extern int optind;
+	bool direction_found = false;
 
 	assert(options && argv);
 
@@ -1037,6 +1041,32 @@ get_login(int argc, char *argv[], OPTIONS *options)
 	if (!options->servername) {
 		usage(options->appname);
 		exit(1);
+	}
+
+	/* If we are using Sybase syntax, then we're going to consume 3 non-switch
+	 * arguments: direction, filename, and database name.
+	 */
+
+	if (strncasecmp(argv[optind], "in", 2) == 0) {
+		optind++;		/* consume direction */
+		if (optind < argc) {
+			options->input_filename = strdup(argv[optind]);
+			optind++;	/* consume filename */
+		}
+		direction_found = true;
+	}
+	else if (strncasecmp(argv[optind], "out", 3) == 0) {
+		optind++;		/* consume direction */
+		if (optind < argc) {
+			options->output_filename = strdup(argv[optind]);
+			optind++;	/* consume filename */
+		}
+		direction_found = true;
+	}
+
+	if (direction_found && optind < argc) {
+		options->database = strdup(argv[optind]);
+		optind++;		/* consume database name*/
 	}
 
 	options->optind = optind;

--- a/src/apps/unittests/common.c
+++ b/src/apps/unittests/common.c
@@ -164,6 +164,18 @@ add_server(char *dest, char *const dest_end)
 	return dest;
 }
 
+char *
+add_login(char *dest, char *const dest_end)
+{
+	dest = add_string(dest, dest_end, " -S ");
+	dest = quote_arg(dest, dest_end, common_pwd.server);
+	dest = add_string(dest, dest_end, " -U ");
+	dest = quote_arg(dest, dest_end, common_pwd.user);
+	dest = add_string(dest, dest_end, " -P ");
+	dest = quote_arg(dest, dest_end, common_pwd.password);
+	return dest;
+}
+
 void
 update_path(void)
 {

--- a/src/apps/unittests/common.h
+++ b/src/apps/unittests/common.h
@@ -29,6 +29,7 @@ char *add_string(char *dest, char *const dest_end, const char *str);
 
 char *add_server(char *dest, char *const dest_end);
 
+char *add_login(char *dest, char *const dest_end);
 /* Add ".." to the environment PATH */
 void update_path(void);
 

--- a/src/apps/unittests/defncopy.c
+++ b/src/apps/unittests/defncopy.c
@@ -86,6 +86,45 @@ defncopy(const char *object_name)
 	output = read_file(output_fn());
 }
 
+/* Builds the command with Sybase syntax */
+static void
+defncopy_sybase(const char *object_name)
+{
+	char cmd[2048];
+	char *const end = cmd + sizeof(cmd) - 1;
+	char *p;
+	FILE *f;
+
+	/* empty input */
+	f = fopen(input_fn(), "w");
+	assert(f);
+	fclose(f);
+
+	strcpy(cmd, "defncopy" EXE_SUFFIX);
+	p = strchr(cmd, 0);
+	p = add_login(p, end);
+	p = add_string(p, end, " out ");
+	p = add_string(p, end, output_fn());
+	if (common_pwd.database[0]) {
+		p = add_string(p, end, " ");
+		p = quote_arg(p, end, common_pwd.database);
+	}
+	p = add_string(p, end, " ");
+	p = quote_arg(p, end, object_name);
+	*p = 0;
+	printf("Executing: %s\n", cmd);
+
+	if (system(cmd) != 0) {
+		printf("Output is:\n");
+		cat(output_fn(), stdout);
+		fprintf(stderr, "Failed command\n");
+		exit(1);
+	}
+	TDS_ZERO_FREE(output);
+
+	output = read_file(output_fn());
+}
+
 /* table with a column name that is also a keyword, should be quoted */
 static void
 test_keyword(void)
@@ -103,6 +142,40 @@ test_keyword(void)
 "  [key]        nvarchar(4000)  NOT NULL\n"
 ")\n");
 	defncopy("dbo.table_with_column_named_key");
+	cat(output_fn(), stdout);
+	normalize_spaces(output);
+	sql =
+"CREATE TABLE [dbo].[table_with_column_named_key]\n"
+" ( [key] nvarchar(4000) NOT NULL\n"
+" )\n"
+"GO";
+	if (strstr(output, sql) == NULL) {
+		fprintf(stderr, "Expected SQL string not found\n");
+		exit(1);
+	}
+	tsql(clean);
+	tsql(sql);
+	tsql(clean);
+}
+
+
+/* same as previous but using Sybase syntax */
+static void
+test_keyword_sybase(void)
+{
+	const char *sql;
+	static const char clean[] =
+		"IF OBJECT_ID('dbo.table_with_column_named_key') IS NOT NULL DROP TABLE dbo.table_with_column_named_key\n";
+
+	tsql(clean);
+	tsql(
+"IF OBJECT_ID('dbo.table_with_column_named_key') IS NOT NULL DROP TABLE dbo.table_with_column_named_key\n"
+"GO\n"
+"CREATE TABLE dbo.table_with_column_named_key\n"
+"(\n"
+"  [key]        nvarchar(4000)  NOT NULL\n"
+")\n");
+	defncopy_sybase("dbo.table_with_column_named_key");
 	cat(output_fn(), stdout);
 	normalize_spaces(output);
 	sql =
@@ -221,6 +294,7 @@ TEST_MAIN()
 		fclose(f);
 
 	test_keyword();
+	test_keyword_sybase();
 	test_index_name_with_space();
 	test_weird_index_names();
 

--- a/vms/vmsarg_mapping_defncopy.c
+++ b/vms/vmsarg_mapping_defncopy.c
@@ -20,45 +20,35 @@
  * Mapping table for the DEFNCOPY command.
  */
 
+#include <stdlib.h>
+
 int vmsarg_mapping (int *nvargs, char *vms_arg[], char *unix_arg[],
 	char *unix_narg[], char *vms_key[], char *unix_key[],
 	char *separator[], int flags[], char *pattern[],
 	char **outverb, int *action_flags, char **arg_symbol,
 	char **image_name)
 {
- *nvargs = 12;
+ *nvargs = 8;
  *action_flags = 1301;
- vms_arg[1] = "DIRECTION";
+
+ vms_arg[1] = "USERNAME";
  flags[1] = 1;
- unix_arg[1] = "$";
+ unix_arg[1] = "-U";
 
- vms_arg[2] = "FILE_NAME";
+ vms_arg[2] = "PASSWORD";
  flags[2] = 1;
- unix_arg[2] = "$";
+ unix_arg[2] = "-P";
 
- vms_arg[3] = "DATABASE_NAME";
+ vms_arg[3] = "SERVER_NAME";
  flags[3] = 1;
- unix_arg[3] = "$";
+ unix_arg[3] = "-S";
 
- vms_arg[4] = "OBJECT_NAME";
+ vms_arg[4] = "VERSION";
  flags[4] = 1;
- unix_arg[4] = "$";
+ unix_arg[4] = "-v";
 
- vms_arg[5] = "USERNAME";
- flags[5] = 1;
- unix_arg[5] = "-U";
-
- vms_arg[6] = "PASSOWRD";
- flags[6] = 1;
- unix_arg[6] = "-P";
-
- vms_arg[7] = "SERVER_NAME";
- flags[7] = 1;
- unix_arg[7] = "-S";
-
- vms_arg[8] = "VERSION";
- flags[8] = 1;
- unix_arg[8] = "-v";
+/*
+ * not implemented
 
  vms_arg[9] = "INTERFACES";
  flags[9] = 1;
@@ -75,6 +65,23 @@ int vmsarg_mapping (int *nvargs, char *vms_arg[], char *unix_arg[],
  vms_arg[12] = "CLIENTCHARSET";
  flags[12] = 1;
  unix_arg[12] = "-J";
+*/
+
+ vms_arg[5] = "DIRECTION";
+ flags[5] = 1;
+ unix_arg[5] = "$";
+
+ vms_arg[6] = "FILE_NAME";
+ flags[6] = 1;
+ unix_arg[6] = "$";
+
+ vms_arg[7] = "DATABASE_NAME";
+ flags[7] = 1;
+ unix_arg[7] = "$";
+
+ vms_arg[8] = "OBJECT_NAME";
+ flags[8] = 1;
+ unix_arg[8] = "$";
 
  return 1;
 }


### PR DESCRIPTION
FreeTDS never supported the documented Sybase syntax for the defncopy command.  Now it can via detecting the presence of an `in` or `out` parameter.  This may be a plus in its own right, but was necessary to get the VMS-style command wrapper working.