### PR TITLE
BCP input with format-file 

### DIFF
--- a/include/freetds/tds.h
+++ b/include/freetds/tds.h
@@ -1734,6 +1734,7 @@ struct tds_bcpinfo
 	bool identity_insert_on;
 	bool xfer_init;
 	bool datarows_locking;
+	bool dry_run;			/** for "bcp in", validate hostfile without uploading rows. */
 	TDS_INT bind_count;
 	TDSRESULTINFO *bindinfo;
 	TDS5COLINFO *sybase_colinfo;

--- a/include/sybdb.h
+++ b/include/sybdb.h
@@ -113,6 +113,9 @@ extern "C"
 #define BCPLABELED 5
 #define BCPHINTS 6
 
+/* FreeTDS-specific BCP options */
+#define BCPDRYRUN 1001
+
 #define DBCMDNONE 0
 #define DBCMDPEND 1
 #define DBCMDSENT 2

--- a/src/apps/freebcp.c
+++ b/src/apps/freebcp.c
@@ -268,7 +268,7 @@ process_parameters(int argc, char **argv, BCPPARAMDATA *pdata)
 	 * Get the rest of the arguments
 	 */
 	optind = 4;		/* start processing options after table, direction, & filename */
-	while ((ch = getopt(argc, argv, "m:f:e:F:L:b:t:r:U:P:i:I:S:h:T:A:o:O:0:C:ncEdvVD:k")) != -1) {
+	while ((ch = getopt(argc, argv, "m:f:e:F:L:b:t:r:U:P:i:I:S:h:T:A:o:O:0:C:ncEdvVD:kj")) != -1) {
 		switch (ch) {
 		case 'v':
 		case 'V':
@@ -361,6 +361,9 @@ process_parameters(int argc, char **argv, BCPPARAMDATA *pdata)
 			break;
 		case 'k':
 			pdata->ignoreDefaults = true;
+			break;
+		case 'j':
+			pdata->dry_run = true;
 			break;
 		case '?':
 		default:
@@ -588,6 +591,7 @@ file_process(BCPPARAMDATA *pdata, DBPROCESS *dbproc, DBINT dir)
 	bcp_control(dbproc, BCPFIRST, pdata->firstrow);
 	bcp_control(dbproc, BCPLAST, pdata->lastrow);
 	bcp_control(dbproc, BCPMAXERRS, pdata->maxerrors);
+	bcp_control(dbproc, BCPDRYRUN, pdata->dry_run);
 
 	switch (file_format) {
 	case BCPFORMAT_FORMATTED:
@@ -620,7 +624,7 @@ file_process(BCPPARAMDATA *pdata, DBPROCESS *dbproc, DBINT dir)
 	if (!process_Eflag(pdata, dbproc))
 		return FALSE;
 
-	printf("\nStarting copy...\n\n");
+	printf("\nStarting copy%s...\n\n", pdata->dry_run ? " (dry run)" : "");
 
 	if (FAIL == bcp_exec(dbproc, &li_rowscopied)) {
 		fprintf(stderr, "bcp copy %s failed\n", (dir == DB_IN) ? "in" : "out");
@@ -630,7 +634,7 @@ file_process(BCPPARAMDATA *pdata, DBPROCESS *dbproc, DBINT dir)
 	if (li_rowsread > li_rowscopied)
 		printf("%d rows unable to be copied.\n", li_rowsread - li_rowscopied);
 
-	printf("%d rows copied.\n", li_rowscopied);
+	printf("%d rows %scopied.\n", li_rowscopied, pdata->dry_run ? "would have been " : "");
 
 	return TRUE;
 }
@@ -720,7 +724,7 @@ pusage(void)
 	fprintf(stderr, "        [-U username] [-P password] [-I interfaces_file] [-S server] [-D database]\n");
 	fprintf(stderr, "        [-v] [-d] [-h \"hint [,...]\" [-O \"set connection_option on|off, ...]\"\n");
 	fprintf(stderr, "        [-A packet size] [-T text or image size] [-E]\n");
-	fprintf(stderr, "        [-i input_file] [-o output_file] [-k]\n");
+	fprintf(stderr, "        [-i input_file] [-o output_file] [-k] [-j]\n");
 	fprintf(stderr, "        \n");
 	fprintf(stderr, "example: freebcp testdb.dbo.inserttest in inserttest.txt -S mssql -U guest -P password -c\n");
 }

--- a/src/apps/freebcp.h
+++ b/src/apps/freebcp.h
@@ -59,6 +59,7 @@ typedef struct pd
 	bool Sflag;
 	bool Aflag;
 	bool Eflag;
+	bool dry_run;
 	bool ignoreDefaults;	/* Really insert a NULL even if default value defined */
 	char *inputfile;
 	char *outputfile;

--- a/src/dblib/bcp.c
+++ b/src/dblib/bcp.c
@@ -1100,6 +1100,7 @@ _bcp_convert_in(DBPROCESS *dbproc, TDS_SERVER_TYPE srctype, const TDS_CHAR *src,
 	coldata->datalen = len;
 	if (variable) {
 		if (len > col->on_server.column_size) {
+			free(cr.c);
 			dbperror(dbproc, SYBECOFL, 0);
 			return TDS_FAIL;
 		}

--- a/src/dblib/bcp.c
+++ b/src/dblib/bcp.c
@@ -556,6 +556,9 @@ bcp_control(DBPROCESS * dbproc, int field, DBINT value)
 	case BCPBATCH:
 		dbproc->hostfileinfo->batch = value;
 		break;
+	case BCPDRYRUN:
+		dbproc->bcpinfo->dry_run = value;
+		break;
 
 	default:
 		dbperror(dbproc, SYBEIFNB, 0);
@@ -1595,6 +1598,12 @@ _bcp_exec_in(DBPROCESS *dbproc, DBINT *rows_copied)
 		if (skip)
 			continue;
 
+		if (dbproc->bcpinfo->dry_run)
+		{
+			++rows_written_so_far;
+			continue;
+		}
+
 		if (TDS_SUCCEED(tds_bcp_send_record(dbproc->tds_socket, dbproc->bcpinfo,
 						    _bcp_no_get_col_data, _bcp_null_error, 0))) {
 
@@ -1632,7 +1641,9 @@ _bcp_exec_in(DBPROCESS *dbproc, DBINT *rows_copied)
 		ret = FAIL;
 	}
 
-	tds_bcp_done(tds, &rows_written_so_far);
+	if ( !dbproc->bcpinfo->dry_run )
+		tds_bcp_done(tds, &rows_written_so_far);
+
 	*rows_copied += rows_written_so_far;
 
 	return ret == NO_MORE_ROWS? SUCCEED : FAIL;	/* (ret is returned from _bcp_read_hostfile) */

--- a/src/dblib/bcp.c
+++ b/src/dblib/bcp.c
@@ -327,9 +327,10 @@ bcp_columns(DBPROCESS * dbproc, int host_colcount)
  * \param host_prefixlen size of the prefix in the datafile column, if any.  For delimited files: zero.  
  *			May be 0, 1, 2, or 4 bytes.  The prefix will be read as an integer (not a character string) from the 
  * 			data file, and will be interpreted the data size of that column, in bytes.  
- * \param host_collen maximum size of datafile column, exclusive of any prefix/terminator.  Just the data, ma'am.  
+ *			The value -1 means to use the default recommended prefix size for the datatype.
+ * \param host_collen maximum size of datafile column exclusive of any prefix/terminator.  Just the data, ma'am.  
  *		Special values:
- *			- \b 0 indicates NULL.  
+ *			- \b  0 indicates a null value for a variable-length field with no prefix/terminator.
  *			- \b -1 for fixed-length non-null datatypes
  *			- \b -1 for variable-length datatypes (e.g. SYBCHAR) where the length is established 
  *				by a prefix/terminator.  
@@ -390,6 +391,8 @@ bcp_colfmt(DBPROCESS * dbproc, int host_colnum, int host_type, int host_prefixle
 		return FAIL;
 	}
 
+	/* Note: MS bcp supports 1, 2, 4, and 8; but not 3; but returns SYBEVDPT on error. 
+	 * -1 is a special value that will be resolved after database connection. */
 	if (host_prefixlen != 0 && host_prefixlen != 1 && host_prefixlen != 2 && host_prefixlen != 4 && host_prefixlen != -1) {
 		dbperror(dbproc, SYBEBCPREF, 0);
 		return FAIL;
@@ -403,11 +406,6 @@ bcp_colfmt(DBPROCESS * dbproc, int host_colnum, int host_type, int host_prefixle
 
 	if (table_colnum > 0 && !is_tds_type_valid(host_type)) {
 		dbperror(dbproc, SYBEUDTY, 0);
-		return FAIL;
-	}
-
-	if (host_type && host_prefixlen == 0 && host_collen == -1 && host_termlen == -1 && !is_fixed_type(host_type)) {
-		dbperror(dbproc, SYBEVDPT, 0);
 		return FAIL;
 	}
 
@@ -430,6 +428,14 @@ bcp_colfmt(DBPROCESS * dbproc, int host_colnum, int host_type, int host_prefixle
 	 */
 	if (host_term == NULL && host_termlen > 0) {
 		dbperror(dbproc, SYBEVDPT, 0);	/* "all variable-length data must have either a length-prefix ..." */
+		return FAIL;
+	}
+
+	/* Does not make sense to have a prefix and a terminator. */
+	if ( host_prefixlen != 0 && host_termlen > 0 ) {
+		tdsdump_log(TDS_DBG_FUNC, 
+			"bcp_colfmt: host column %d has a prefix and a terminator.\n", host_colnum);
+		dbperror(dbproc, SYBEVDPT, 0);
 		return FAIL;
 	}
 
@@ -1171,6 +1177,7 @@ static STATUS
 _bcp_read_hostfile(DBPROCESS *dbproc, TDSFILESTREAM *stream, bool *row_error, bool skip)
 {
 	int i;
+	bool truncation_warning = false;
 
 	tdsdump_log(TDS_DBG_FUNC, "_bcp_read_hostfile(%p, %p, %p, %d)\n", dbproc, stream, row_error, skip);
 	assert(dbproc);
@@ -1181,8 +1188,8 @@ _bcp_read_hostfile(DBPROCESS *dbproc, TDSFILESTREAM *stream, bool *row_error, bo
 	for (i = 0; i < dbproc->hostfileinfo->host_colcount; i++) {
 		TDSCOLUMN *bcpcol = NULL;
 		BCP_HOSTCOLINFO *hostcol;
-		TDS_CHAR *coldata;
-		int collen = 0;
+		TDS_CHAR *coldata = NULL;
+		int collen = 0;		/* How many bytes to read from hostfile */
 		bool data_is_null = false;
 		offset_type col_start;
 
@@ -1208,9 +1215,30 @@ _bcp_read_hostfile(DBPROCESS *dbproc, TDSFILESTREAM *stream, bool *row_error, bo
 			assert(bcpcol != NULL);
 		}
 
-		/* detect prefix len */
+		/* detect prefix len. NOTE: requires server connection, because
+		 * it will add a prefix to a prefix-less fixed type if the column
+		 * is nullable. */
 		if (bcpcol && hostcol->prefix_len == -1)
 			bcp_cache_prefix_len(hostcol, bcpcol);
+
+		/* If a variable field has no prefix or terminator, its length can
+		 * only be set by hostcol->column_len.
+		 * 
+		 * NOTE: Must check do this after bcp_cache_prefix_len() as that
+		 * could set or unset the prefix_len. */
+		if (hostcol->prefix_len == 0 && hostcol->term_len <= 0 && !is_fixed_type(hostcol->datatype)) {
+			if (hostcol->column_len == -1) {
+				/* If no column max size given either, we can't know how much to read. */
+				dbperror(dbproc, SYBEVDPT, 0);
+				return FAIL;
+			}
+
+			/* Column size 0, special case to indicate null field. */
+			if (hostcol->column_len == 0)
+				data_is_null = true;
+
+			collen = hostcol->column_len;
+		}
 
 		/* a prefix length, if extant, specifies how many bytes to read */
 		if (hostcol->prefix_len > 0) {
@@ -1220,6 +1248,7 @@ _bcp_read_hostfile(DBPROCESS *dbproc, TDSFILESTREAM *stream, bool *row_error, bo
 				TDS_INT li;
 			} u;
 
+			/* note: prefixes are in native endianness. */
 			switch (hostcol->prefix_len) {
 			case 1:
 				if (tds_file_stream_read_raw(stream, &u.ti, 1) != 1)
@@ -1237,48 +1266,54 @@ _bcp_read_hostfile(DBPROCESS *dbproc, TDSFILESTREAM *stream, bool *row_error, bo
 				collen = u.li;
 				break;
 			default:
-				/* FIXME return error, remember that prefix_len can be 3 */
-				assert(hostcol->prefix_len <= 4);
-				break;
+				/* Should be unreachable - bcp_colfmt() also checked this. */
+				dbperror(dbproc, SYBEBCPREF, 0);
+				return FAIL;
 			}
 
 			/* TODO test all NULL types */
-			/* TODO for < -1 error */
-			if (collen <= -1) {
+			/* Length prefix of -1 means a null value. */
+			if (collen <= -1)
 				data_is_null = true;
-				collen = 0;
+		}
+
+		/* Report an error if a fixed-width type has mismatching prefix.
+		 * Note: fixed-width types are allowed a prefix in order to be nullable.
+		 */
+		if (!data_is_null && is_fixed_type(hostcol->datatype)) {
+			int fixed_size = tds_get_size_by_type(hostcol->datatype);
+
+			if (collen > 0 && collen != fixed_size) {
+				tdsdump_log(TDS_DBG_FUNC,
+					"bcp_colfmt: invalid collen %d for fixed type %d.\n",
+					collen, hostcol->datatype);
+				dbperror(dbproc, SYBECSYN, 0);
+				return FAIL;
 			}
-		}
 
-		/* if (Max) column length specified take that into consideration. (Meaning what, exactly?) */
+			collen = fixed_size;
+		}		
 
-		if (!data_is_null && hostcol->column_len >= 0) {
-			if (hostcol->column_len == 0)
-				data_is_null = true;
-			else if (collen)
-				collen = TDS_MIN(hostcol->column_len, collen);
-			else
-				collen = hostcol->column_len;
-		}
-
-		tdsdump_log(TDS_DBG_FUNC, "prefix_len = %d collen = %d \n", hostcol->prefix_len, collen);
-
-		/* Fixed Length data - this overrides anything else specified */
-
-		if (is_fixed_type(hostcol->datatype))
-			collen = tds_get_size_by_type(hostcol->datatype);
+		tdsdump_log(TDS_DBG_FUNC, "prefix_len = %d, term_len = %d, collen = %d\n", hostcol->prefix_len, hostcol->term_len, collen);
 
 		col_start = tds_file_stream_tell(stream);
 
-		/*
-		 * The data file either contains prefixes stating the length, or is delimited.  
-		 * If delimited, we "measure" the field by looking for the terminator, then read it, 
-		 * and set collen to the field's post-iconv size.  
+		/* We will perform iconv on hostfile text only when the field has a
+		 * terminator, because that indicates it's a text file and would be
+		 * in the client charset.  Prefixed fields indicate a host-native
+		 * file, and our tds_bcp_fread() function doesn't support
+		 * reading an exact number of bytes anyway.
+		 * 
+		 * NOTE: bcp_colfmt() prevents field having both prefix and terminator.
 		 */
-		if (hostcol->term_len > 0) { /* delimited data file */
+		if (data_is_null)
+			collen = 0;
+		else if (hostcol->term_len > 0) {
 			size_t col_bytes;
 			TDSRET conv_res;
 
+			/* Note: Important to not stop reading early based on a field width
+			 * setting (this would cause hostfile to get out of sync). */
 			coldata = NULL;
 			conv_res = tds_bcp_fread(dbproc->tds_socket, bcpcol ? bcpcol->char_conv : NULL, stream,
 						 (const char *) hostcol->terminator, hostcol->term_len, &coldata, &col_bytes);
@@ -1308,6 +1343,7 @@ _bcp_read_hostfile(DBPROCESS *dbproc, TDSFILESTREAM *stream, bool *row_error, bo
 				return FAIL;
 			}
 
+			/* collen is the post-iconv size of the field here */
 			collen = (int)col_bytes;
 			if (collen == 0)
 				data_is_null = true;
@@ -1326,7 +1362,8 @@ _bcp_read_hostfile(DBPROCESS *dbproc, TDSFILESTREAM *stream, bool *row_error, bo
 			 *    passed to tds_convert() without even waving to iconv().  For English dates, this works, 
 			 *    because English dates expressed as UTF-8 strings are indistinguishable from the ASCII.  
 			 */
-		} else {	/* unterminated field */
+		} else { /* Length known due to being a fixed field and/or prefixed. */
+			assert(collen > 0);	// The above logic should guarantee this.
 
 			coldata = tds_new(TDS_CHAR, 1 + collen);
 			if (coldata == NULL) {
@@ -1335,27 +1372,22 @@ _bcp_read_hostfile(DBPROCESS *dbproc, TDSFILESTREAM *stream, bool *row_error, bo
 				return FAIL;
 			}
 
-			coldata[collen] = 0;
-			if (collen) {
-				/* 
-				 * Read and convert the data
-				 * TODO: Call tds_bcp_fread() instead of fread(3).
-				 *       The columns should each have their iconv cd set, and noncharacter data
-				 *       should have -1 as the iconv cd, causing tds_bcp_fread() to not attempt
-				 * 	 any conversion.  We do not need a datatype switch here to decide what to do.  
-				 *	 As of 0.62, this *should* actually work.  All that remains is to change the
-				 *       call and test it.
-				 */
-				tdsdump_log(TDS_DBG_FUNC, "Reading %d bytes from hostfile.\n", collen);
-				if (tds_file_stream_read_raw(stream, coldata, collen) != collen) {
-					free(coldata);
-					return _bcp_check_eof(dbproc, stream, i);
-				}
+			tdsdump_log(TDS_DBG_FUNC, "Reading %d bytes from hostfile.\n", collen);
+			if (tds_file_stream_read_raw(stream, coldata, collen) != collen) {
+				free(coldata);
+				return _bcp_check_eof(dbproc, stream, i);
 			}
+
+			/* Not sure why this is here, the terminated-read branch doesn't do it. */
+			coldata[collen] = 0;
 		}
 
 		/* 
-		 * At this point, however the field was read, however big it was, its address is coldata and its size is collen.
+		 * At this point, however the field was read, however big it was, its
+		 * address is coldata (which is a dynamically allocated buffer or NULL),
+		 * and its size is collen.
+		 * NOTE: we intentionally do not force truncation to hostcol->column_len
+		 * if a prefix/terminator specified longer data; matching behaviour of MS BCP 16.0.
 		 */
 		tdsdump_log(TDS_DBG_FUNC, "Data read from hostfile: collen is now %d, data_is_null is %d\n", collen, data_is_null);
 		if (!skip && bcpcol) {
@@ -1367,6 +1399,21 @@ _bcp_read_hostfile(DBPROCESS *dbproc, TDSFILESTREAM *stream, bool *row_error, bo
 				TDS_SERVER_TYPE desttype;
 
 				desttype = tds_get_conversion_type(bcpcol->column_type, bcpcol->column_size);
+
+				/* _bcp_convert_in will give an error if our char data exceeds
+				 * the server column size, so we need to deal with that now
+				 */
+				if (desttype==SYBCHAR || desttype==SYBVARCHAR) {
+					if (collen > bcpcol->on_server.column_size) {
+						tdsdump_log(TDS_DBG_INFO1, 
+							"Warning: _bcp_read_hostfile: %d bytes at offset 0x%" PRIx64
+							" in the data file: truncated to server size %d.\n",
+							collen, (TDS_INT8)col_start, (int)bcpcol->on_server.column_size);
+
+						collen = bcpcol->on_server.column_size;
+						truncation_warning = true;
+					}
+				}
 
 				rc = _bcp_convert_in(dbproc, hostcol->datatype, (const TDS_CHAR*) coldata, collen,
 						     desttype, bcpcol);
@@ -1395,6 +1442,10 @@ _bcp_read_hostfile(DBPROCESS *dbproc, TDSFILESTREAM *stream, bool *row_error, bo
 		}
 		free(coldata);
 	}
+
+	if (dbproc->bcpinfo->dry_run && truncation_warning)
+		printf("Warning: data truncated due to server column being too small; see log file for detail.\n");
+
 	return MORE_ROWS;
 }
 

--- a/src/dblib/unittests/.gitattributes
+++ b/src/dblib/unittests/.gitattributes
@@ -1,0 +1,3 @@
+*.in text eol=lf
+*.exp text eol=lf
+

--- a/src/dblib/unittests/common.c
+++ b/src/dblib/unittests/common.c
@@ -344,7 +344,7 @@ syb_msg_handler(DBPROCESS * dbproc, DBINT msgno, int msgstate, int severity, cha
 }
 
 int
-syb_err_handler(DBPROCESS * dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr)
+syb_err_logmsg (DBPROCESS * dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr)
 {
 	int *pexpected_dberr;
 
@@ -373,6 +373,16 @@ syb_err_handler(DBPROCESS * dbproc, int severity, int dberr, int oserr, char *db
 		"DB-LIBRARY error (dberr %d (severity %d): \"%s\"; oserr %d: \"%s\")\n",
 		dberr, severity, dberrstr ? dberrstr : "(null)", oserr, oserrstr ? oserrstr : "(null)");
 	fflush(stderr);
+
+	return 0;
+}
+
+int
+syb_err_handler(DBPROCESS * dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr)
+{
+	int retval = syb_err_logmsg(dbproc, severity, dberr, oserr, dberrstr, oserrstr);
+	if (retval != 0)
+		return retval;
 
 	/*
 	 * If the dbprocess is dead or the dbproc is a NULL pointer and

--- a/src/dblib/unittests/common.h
+++ b/src/dblib/unittests/common.h
@@ -93,6 +93,7 @@ int read_login_info(int argc, char **argv);
 int syb_msg_handler(DBPROCESS * dbproc,
 		    DBINT msgno, int msgstate, int severity, char *msgtext, char *srvname, char *procname, int line);
 int syb_err_handler(DBPROCESS * dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr);
+int syb_err_logmsg (DBPROCESS * dbproc, int severity, int dberr, int oserr, char *dberrstr, char *oserrstr);
 
 RETCODE sql_cmd(DBPROCESS *dbproc);
 RETCODE sql_rewind(void);

--- a/src/dblib/unittests/t0016.c
+++ b/src/dblib/unittests/t0016.c
@@ -392,9 +392,11 @@ compare_files(const char *fn1, const char *fn2)
 			if (s1 != s2 || memcmp(line1, line2, s1) != 0) {
 				equal = false;
 				failure("File different at line %d\n"
-					"  input: %s"
+					" %s: %s"
 					" output: %s",
-					line, line1, line2);
+					line,
+					fn1[strlen(fn1)-1] == 'p' ? "expect" : " input",
+					line1, line2);
 			}
 		}
 	} else {

--- a/src/dblib/unittests/t0016.c
+++ b/src/dblib/unittests/t0016.c
@@ -179,21 +179,31 @@ test_file(const char *fn)
 	char hints[64];
 	char colin[64] = { 0 };
 	char colout[64] = { 0 };
+	bool fmt_file_exists = false;
 
 	FILE *input_file;
 
 	char sql_file[256];
 	char in_file[256];
 	char exp_file[256];
+	char fmt_file[256];
 
 	snprintf(sql_file, sizeof(sql_file), "%s/%s.sql", FREETDS_SRCDIR, fn);
 	snprintf(in_file, sizeof(in_file), "%s/%s.in", FREETDS_SRCDIR, fn);
 	snprintf(exp_file, sizeof(exp_file), "%s/%s.exp", FREETDS_SRCDIR, fn);
+	snprintf(fmt_file, sizeof(fmt_file), "%s/%s.fmt", FREETDS_SRCDIR, fn);
 
 	strlcpy(table_name, TABLE_NAME, sizeof(table_name));
 	hints[0] = 0;
 
 	printf("===== %s =====\n", fn);
+	input_file = fopen(fmt_file, "r");
+	if (input_file)
+	{
+		fmt_file_exists = true;
+		fclose(input_file);
+	}
+
 	input_file = fopen(in_file, "r");
 	if (!input_file) {
 		sprintf(in_file, "%s.in", fn);
@@ -282,11 +292,15 @@ test_file(const char *fn)
 		failure("bcp_init failed\n");
 
 	if (hints[0])
-		bcp_options(dbproc, BCPHINTS, (BYTE *) hints, strlen(hints));
+		bcp_options(dbproc, BCPHINTS, (BYTE *) hints, (int)strlen(hints));
 
 	printf("return from bcp_init = %d\n", ret);
 
-	format_columns(num_cols, colin);
+	/* Check for a format file; if not, then format all columns as SYBCHAR tab/newline delimit */
+	if ( fmt_file_exists && SUCCEED == bcp_readfmt(dbproc, fmt_file))
+		printf("Loaded %s\n", fmt_file);
+	else
+		format_columns(num_cols, colin);
 
 	ret = bcp_exec(dbproc, &rows_copied);
 	if (ret != SUCCEED || rows_copied != num_rows)
@@ -311,7 +325,10 @@ test_file(const char *fn)
 			continue;
 	}
 
-	format_columns(num_cols, colout);
+	if (fmt_file_exists && SUCCEED == bcp_readfmt(dbproc, fmt_file))
+		printf("Loaded %s\n", fmt_file);
+	else
+		format_columns(num_cols, colout);
 
 	ret = bcp_exec(dbproc, &rows_copied);
 	if (ret != SUCCEED || rows_copied != num_rows)

--- a/src/dblib/unittests/t0016.c
+++ b/src/dblib/unittests/t0016.c
@@ -438,10 +438,13 @@ compare_files(const char *fn1, const char *fn2)
 				equal = false;
 				failure("File different at line %d\n"
 					" %s: %s"
-					" output: %s",
+					" output: %s%s",
 					line,
-					fn1[strlen(fn1)-1] == 'p' ? "expect" : " input",
-					line1, line2);
+					fn1[strlen(fn1) - 1] == 'p' ? "expect" : " input",
+					line1, line2,
+					/* don't double-newline if expected output had one already */
+					(line2[0] && line2[strlen(line2) - 1] == '\n') ? "" : "\n");
+
 			}
 		}
 	} else {

--- a/src/dblib/unittests/t0016.c
+++ b/src/dblib/unittests/t0016.c
@@ -36,7 +36,7 @@ TEST_MAIN()
 {
 	LOGINREC *login;
 	char in_file[30];
-	unsigned int n;
+	unsigned int n = 1, end = 100;
 
 	setbuf(stdout, NULL);
 	setbuf(stderr, NULL);
@@ -70,8 +70,20 @@ TEST_MAIN()
 	/* First testcase already had SQL opened by read_login_info() */
 	strcpy(in_file, INFILE_NAME);
 
+	/* Developer option to focus on specific tests */
+	{
+		char const* var = getenv("TDST0016_BEGIN");
+		if (var)
+			n = atoi(var);
+		var = getenv("TDST0016_END");
+		if (var)
+			end = atoi(var);
+	}
+
 	/* Execute all testcases (carry on even if one fails) */
-	for (n = 1; n <= 100; ++n) {
+	if (n < 1)
+		n = 1;
+	for (; n <= end; ++n) {
 		test_file(in_file);
 		sprintf(in_file, "%s_%d", INFILE_NAME, n);
 		if (sql_reopen(in_file) != SUCCEED) {

--- a/src/dblib/unittests/t0016.c
+++ b/src/dblib/unittests/t0016.c
@@ -32,11 +32,24 @@ static unsigned count_file_rows(FILE *f);
 static size_t fgets_raw(char *s, int len, FILE * f);
 static DBPROCESS *dbproc;
 
+/* custom error handler for clean exit */
+static int
+t0016_syb_err_handler(DBPROCESS* dbproc, int severity, int dberr, int oserr, char* dberrstr, char* oserrstr)
+{
+	int retval = syb_err_logmsg(dbproc, severity, dberr, oserr, dberrstr, oserrstr);
+	if (retval != 0)
+		return retval;
+
+	failed = true;
+	return INT_CANCEL;
+}
+
 TEST_MAIN()
 {
 	LOGINREC *login;
 	char in_file[30];
 	unsigned int n = 1, end = 100;
+	unsigned int n_pass = 0, n_fail = 0;
 
 	setbuf(stdout, NULL);
 	setbuf(stderr, NULL);
@@ -84,19 +97,22 @@ TEST_MAIN()
 	if (n < 1)
 		n = 1;
 	for (; n <= end; ++n) {
+		failed = FALSE;
 		test_file(in_file);
+		failed ? ++n_fail : ++n_pass;
+
 		sprintf(in_file, "%s_%d", INFILE_NAME, n);
-		if (sql_reopen(in_file) != SUCCEED) {
-			printf("===== End of t0016 subtests =====\n");
+		if (sql_reopen(in_file) != SUCCEED)
 			break;
-		}
 	}
+	printf("===== End of t0016 subtests =====\n");
 
 	dbclose(dbproc);
 	dbexit();
 
-	printf("dblib %s on %s\n", (failed ? "failed!" : "okay"), __FILE__);
-	return failed ? 1 : 0;
+	printf("dblib t0016: %d pass, %d fail.\n", n_pass, n_fail);
+	printf("=================================\n");
+	return n_fail? 1 : 0;
 }
 
 static bool got_error = false;
@@ -275,7 +291,7 @@ test_file(const char *fn)
 	while (dbresults(dbproc) != NO_MORE_RESULTS)
 		continue;
 
-	dberrhandle(syb_err_handler);
+	dberrhandle(t0016_syb_err_handler);
 	dbmsghandle(syb_msg_handler);
 
 	if (got_error) {

--- a/src/dblib/unittests/t0016_22.exp
+++ b/src/dblib/unittests/t0016_22.exp
@@ -1,0 +1,1 @@
+1234 thirtytwo-characters-----------.Next field tabdelim	2345

--- a/src/dblib/unittests/t0016_22.exp
+++ b/src/dblib/unittests/t0016_22.exp
@@ -1,1 +1,1 @@
-1234 thirtytwo-characters-----------.Next field tabdelim	2345
+1234 thirtytwo-characters-----------.Next field tabdelim	ExactlyTen2345

--- a/src/dblib/unittests/t0016_22.fmt
+++ b/src/dblib/unittests/t0016_22.fmt
@@ -1,7 +1,8 @@
 10.0
-5
+6
 1       SYBINT4 0       4       ""      1       Foo
 2		SYBCHAR	1		50		""		2		S1
 3		SYBCHAR	0		50		"\t"	3		S2
 4		SYBCHAR	0		10		""	4		S3
-5       SYBCHAR 0       4       "\n"      5       Bar
+5		SYBCHAR	0		0		""	5		S4null
+6       SYBINT4 0       4       "\n"      6       Bar

--- a/src/dblib/unittests/t0016_22.fmt
+++ b/src/dblib/unittests/t0016_22.fmt
@@ -1,6 +1,7 @@
 10.0
-4
+5
 1       SYBINT4 0       4       ""      1       Foo
-2		SYBCHAR	1		32		""		2		S1
-3		SYBCHAR	0		20		"\t"	3		S2
-4       SYBCHAR 0       4       "\n"      4       Bar
+2		SYBCHAR	1		50		""		2		S1
+3		SYBCHAR	0		50		"\t"	3		S2
+4		SYBCHAR	0		10		""	4		S3
+5       SYBCHAR 0       4       "\n"      5       Bar

--- a/src/dblib/unittests/t0016_22.fmt
+++ b/src/dblib/unittests/t0016_22.fmt
@@ -1,0 +1,6 @@
+10.0
+4
+1       SYBINT4 0       4       ""      1       Foo
+2		SYBCHAR	1		32		""		2		S1
+3		SYBCHAR	0		20		"\t"	3		S2
+4       SYBCHAR 0       4       "\n"      4       Bar

--- a/src/dblib/unittests/t0016_22.in
+++ b/src/dblib/unittests/t0016_22.in
@@ -1,1 +1,1 @@
-1234#thirtytwo-characters-----------.###Next field tabdelim serversize20.	2345
+1234#thirtytwo-characters-----------.###Next field tabdelim serversize20.	ExactlyTen2345

--- a/src/dblib/unittests/t0016_22.in
+++ b/src/dblib/unittests/t0016_22.in
@@ -1,0 +1,1 @@
+1234#thirtytwo-characters-----------.###Next field tabdelim serversize20.	2345

--- a/src/dblib/unittests/t0016_22.sql
+++ b/src/dblib/unittests/t0016_22.sql
@@ -1,4 +1,4 @@
-create table #dblib0016 (f0 int not null, f1 varchar(32) not null, f2 varchar(20) not null, f3 varchar(10) not null, f4 int not null)
+create table #dblib0016 (f0 int not null, f1 varchar(32) not null, f2 varchar(20) not null, f3 varchar(10) not null, f4 varchar(12) null, f5 int not null)
 go
 select * from #dblib0016 where 0=1
 go

--- a/src/dblib/unittests/t0016_22.sql
+++ b/src/dblib/unittests/t0016_22.sql
@@ -1,4 +1,4 @@
-create table #dblib0016 (f0 int not null, f1 varchar(32) not null, f2 varchar(20) not null, f3 int not null)
+create table #dblib0016 (f0 int not null, f1 varchar(32) not null, f2 varchar(20) not null, f3 varchar(10) not null, f4 int not null)
 go
 select * from #dblib0016 where 0=1
 go

--- a/src/dblib/unittests/t0016_22.sql
+++ b/src/dblib/unittests/t0016_22.sql
@@ -1,0 +1,8 @@
+create table #dblib0016 (f0 int not null, f1 varchar(32) not null, f2 varchar(20) not null, f3 int not null)
+go
+select * from #dblib0016 where 0=1
+go
+select * from #dblib0016 where 0=1
+go
+drop table #dblib0016
+go


### PR DESCRIPTION
For BCP input with format files:

- support this in test suite and add a test case
- perform more validation that the format file doesn't specify contradictory requirements
- validate length prefix, if present, on fixed fields
- reject terminated fields also having a length prefix, other than a null indicator  (unclear what this means anyway, considering that iconv may be happening)
- improve code commentary
- Add dry-run option for "bcp in" to check hostfile for fatal errors without doing a partial database write in case there were errors.

Semantic changes:
- when reading a variable field from the hostfile, that has a prefix or terminator, the prefix/terminator governs how many bytes to read from the hostfile. It should not perform a short read based on format file's column size, nor server column size.  It will truncate the data after reading, to match the server column size. (Matches behaviour of MS BCP)
- format file specifying column size 0 is only interpreted as null now for fixed fields with no prefix/terminator (Matches behaviour of MS BCP). This field is disregarded when the size is known in another way (fixed type, or variable type with a prefix or terminator).

Regarding iconv:  the existing code only performed iconv for a character field with a terminator; otherwise data was read raw. This commit does not change that behaviour, but documents it more clearly in the code.  

The previous code had comments indicating an intent to perform iconv for all cases of character fields; but (a) that's not so easy to implement as our stream read function does not have the option to read a set number of bytes and perform iconv , and (b) I don't think we actually want to do that anyway; because if a field does not have a terminator it means it's probably part of either a native-mode load, or a format file that behaves like native-mode, which means we want maximum performance by doing raw data in/out without conversion.

I did some ad-hoc testing of cases that were expected to cause failure,  since the test suite currently doesn't provide for a case that is expected to fail. 
